### PR TITLE
Fixes PSAT machines handling of bases and PSAT OEL

### DIFF
--- a/OpenIPSL/Electrical/Controls/PSAT/OEL/FieldCurrent.mo
+++ b/OpenIPSL/Electrical/Controls/PSAT/OEL/FieldCurrent.mo
@@ -1,18 +1,19 @@
 within OpenIPSL.Electrical.Controls.PSAT.OEL;
 model FieldCurrent
+  "Estimates the field current from P,Q,V and the d- and q-axis reactances"
 
-  Modelica.Blocks.Interfaces.RealInput v "generator terminal voltage"
+  Modelica.Blocks.Interfaces.RealInput v "generator terminal voltage (pu)"
     annotation (Placement(transformation(extent={{-70,30},{-50,50}}),
         iconTransformation(extent={{-116,43},{-84,77}})));
-  Modelica.Blocks.Interfaces.RealInput p "active power " annotation (Placement(
-        transformation(extent={{-70,-10},{-50,10}}),iconTransformation(extent={
-            {-117,-17},{-83,17}})));
-  Modelica.Blocks.Interfaces.RealInput q "reactive power" annotation (Placement(
-        transformation(extent={{-70,-50},{-50,-30}}), iconTransformation(extent
-          ={{-117,-77},{-83,-43}})));
-  Modelica.Blocks.Interfaces.RealOutput ifield annotation (Placement(
-        transformation(extent={{96,-10},{116,10}}), iconTransformation(extent={
-            {94,-17},{126,17}})));
+  Modelica.Blocks.Interfaces.RealInput p "active power (pu)" annotation (
+      Placement(transformation(extent={{-70,-10},{-50,10}}), iconTransformation(
+          extent={{-117,-17},{-83,17}})));
+  Modelica.Blocks.Interfaces.RealInput q "reactive power (pu)" annotation (
+      Placement(transformation(extent={{-70,-50},{-50,-30}}),
+        iconTransformation(extent={{-117,-77},{-83,-43}})));
+  Modelica.Blocks.Interfaces.RealOutput ifield "estimated field current (pu)"
+    annotation (Placement(transformation(extent={{96,-10},{116,10}}),
+        iconTransformation(extent={{94,-17},{126,17}})));
   parameter Real xd;
   parameter Real xq;
 protected
@@ -21,7 +22,7 @@ protected
 equation
   gamma_p = xq*p/v;
   gamma_q = xq*q/v;
-  ifield = sqrt((v + gamma_q)^2 + p^2) + (xd/xq + 1)*(gamma_q*(v + gamma_q) +
+  ifield = sqrt((v + gamma_q)^2 + p^2) + (xd/xq - 1)*(gamma_q*(v + gamma_q) +
     gamma_p)/sqrt((v + gamma_q)^2 + p^2);
   annotation (
     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{

--- a/OpenIPSL/Electrical/Controls/PSAT/OEL/OEL.mo
+++ b/OpenIPSL/Electrical/Controls/PSAT/OEL/OEL.mo
@@ -1,6 +1,6 @@
 within OpenIPSL.Electrical.Controls.PSAT.OEL;
 model OEL "PSATs Over-Excitation Limiter"
-
+  outer OpenIPSL.Electrical.SystemBase SysData;
   Modelica.Blocks.Interfaces.RealInput v "Generator terminal voltage (pu)"
     annotation (Placement(transformation(extent={{-112,50},{-92,70}}),
         iconTransformation(extent={{-104,48},{-80,72}})));
@@ -8,29 +8,33 @@ model OEL "PSATs Over-Excitation Limiter"
       Placement(transformation(extent={{-112,-10},{-92,10}}),iconTransformation(
           extent={{-104,8},{-80,32}})));
   Modelica.Blocks.Interfaces.RealInput q "Reactive power (pu)" annotation (
-      Placement(transformation(extent={{-112,-72},{-92,-52}}),
+      Placement(transformation(extent={{-112,-70},{-92,-50}}),
         iconTransformation(extent={{-104,-32},{-80,-8}})));
   FieldCurrent field_current(xd=xd, xq=xq)
-    annotation (Placement(transformation(extent={{-76,-12},{-56,12}})));
-
+    annotation (Placement(transformation(extent={{-56,-12},{-36,12}})));
   Modelica.Blocks.Interfaces.RealOutput v_ref annotation (Placement(
         transformation(extent={{94,-10},{114,10}}), iconTransformation(extent={
             {92,-12},{116,12}})));
-  parameter Real T0 "Integrator time constant (s)";
-  parameter Real xd "d-axis estimated generator reactance (pu)";
-  parameter Real xq "q-axis estimated generator reactance (pu)";
-  parameter Real if_lim "Maximum filed current (pu)";
-  parameter Real vOEL_max "Maximum output signal (pu)";
+  parameter Real T0=10 "Integrator time constant (s)";
+  parameter Real xd "d-axis estimated generator reactance (pu, machine base)";
+  parameter Real xq "q-axis estimated generator reactance (pu, machine base)";
+  parameter Real if_lim "Maximum field current (pu, machine base)";
+  parameter Real vOEL_max "Maximum output signal (pu, machine base)";
+  parameter OpenIPSL.Types.ApparentPowerMega S_mb=SysData.S_b
+    "Machine base power";
+protected
+  parameter Real CoB=SysData.S_b/S_mb "ratio of system base and machine base";
+public
   Modelica.Blocks.Math.Feedback add
-    annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
+    annotation (Placement(transformation(extent={{-30,-10},{-10,10}})));
   Modelica.Blocks.Sources.Constant currentLimit(k=if_lim) annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
-        origin={-40,-60})));
+        origin={-20,-60})));
   Modelica.Blocks.Continuous.LimIntegrator limIntegrator(k=1/T0, outMax=
         vOEL_max)
-    annotation (Placement(transformation(extent={{12,-10},{32,10}})));
+    annotation (Placement(transformation(extent={{46,10},{66,30}})));
   Modelica.Blocks.Interfaces.RealInput v_ref0 "Generator terminal voltage (pu)"
     annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
@@ -40,32 +44,40 @@ model OEL "PSATs Over-Excitation Limiter"
         rotation=-90,
         origin={0,112})));
   Modelica.Blocks.Nonlinear.Limiter limiter(uMin=0, uMax=Modelica.Constants.inf)
-    annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
+    annotation (Placement(transformation(extent={{2,-10},{22,10}})));
   Modelica.Blocks.Math.Feedback difference annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
-        rotation=0,
-        origin={40,68})));
+        rotation=270,
+        origin={80,20})));
+  Modelica.Blocks.Math.Gain CoBq(k=CoB)
+    annotation (Placement(transformation(extent={{-86,-66},{-74,-54}})));
+  Modelica.Blocks.Math.Gain CoBp(k=CoB)
+    annotation (Placement(transformation(extent={{-86,-6},{-74,6}})));
 equation
   connect(field_current.ifield, add.u1)
-    annotation (Line(points={{-55,0},{-48,0}}, color={0,0,127}));
+    annotation (Line(points={{-35,0},{-28,0}}, color={0,0,127}));
   connect(currentLimit.y, add.u2)
-    annotation (Line(points={{-40,-49},{-40,-49},{-40,-8}}, color={0,0,127}));
+    annotation (Line(points={{-20,-49},{-20,-8}}, color={0,0,127}));
   connect(limIntegrator.u, limiter.y)
-    annotation (Line(points={{10,0},{1,0}}, color={0,0,127}));
+    annotation (Line(points={{44,20},{40,20},{40,0},{23,0}}, color={0,0,127}));
   connect(add.y, limiter.u)
-    annotation (Line(points={{-31,0},{-31,0},{-22,0}}, color={0,0,127}));
-  connect(v_ref, difference.y) annotation (Line(points={{104,0},{80,0},{80,68},
-          {49,68}}, color={0,0,127}));
-  connect(p, field_current.p)
-    annotation (Line(points={{-102,0},{-76,0}}, color={0,0,127}));
-  connect(field_current.v, v) annotation (Line(points={{-76,7.2},{-88,7.2},{-88,
+    annotation (Line(points={{-11,0},{-11,0},{0,0}}, color={0,0,127}));
+  connect(v_ref, difference.y)
+    annotation (Line(points={{104,0},{80,0},{80,11}}, color={0,0,127}));
+  connect(field_current.v, v) annotation (Line(points={{-56,7.2},{-60,7.2},{-60,
           60},{-102,60}}, color={0,0,127}));
-  connect(q, field_current.q) annotation (Line(points={{-102,-62},{-88,-62},{-88,
-          -7.2},{-76,-7.2}}, color={0,0,127}));
   connect(limIntegrator.y, difference.u2)
-    annotation (Line(points={{33,0},{40,0},{40,60}}, color={0,0,127}));
-  connect(difference.u1, v_ref0) annotation (Line(points={{32,68},{32,68},{2,68},
+    annotation (Line(points={{67,20},{67,20},{72,20}}, color={0,0,127}));
+  connect(difference.u1, v_ref0) annotation (Line(points={{80,28},{80,76},{2,76},
           {2,110}}, color={0,0,127}));
+  connect(CoBp.u, p)
+    annotation (Line(points={{-87.2,0},{-87.2,0},{-102,0}}, color={0,0,127}));
+  connect(CoBp.y, field_current.p)
+    annotation (Line(points={{-73.4,0},{-73.4,0},{-56,0}}, color={0,0,127}));
+  connect(q, CoBq.u) annotation (Line(points={{-102,-60},{-94,-60},{-87.2,-60}},
+        color={0,0,127}));
+  connect(CoBq.y, field_current.q) annotation (Line(points={{-73.4,-60},{-60,-60},
+          {-60,-7.2},{-56,-7.2}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
             100,100}})),

--- a/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
@@ -46,12 +46,12 @@ partial model baseMachine
         origin={110,30},
         extent={{-10,-10},{10,10}},
         rotation=0)));
-  Modelica.Blocks.Interfaces.RealOutput P(start=P_0/S_b) "Active power (pu)"
+  Modelica.Blocks.Interfaces.RealOutput P(start=p0) "Active power (pu)"
     annotation (Placement(visible=true, transformation(
         origin={110,-30},
         extent={{-10,-10},{10,10}},
         rotation=0)));
-  Modelica.Blocks.Interfaces.RealOutput Q(start=Q_0/S_b) "Reactive power (pu)"
+  Modelica.Blocks.Interfaces.RealOutput Q(start=q0) "Reactive power (pu)"
     annotation (Placement(visible=true, transformation(
         origin={110,-70},
         extent={{-10,-10},{10,10}},
@@ -124,15 +124,15 @@ equation
   anglev = atan2(p.vi, p.vr);
   der(delta) = w_b*(w - 1);
   if D > Modelica.Constants.eps then
-    der(w) = (pm - (P/CoB) - D*(w - 1))/M;
+    der(w) = ((pm - P)/CoB - D*(w - 1))/M;
   else
-    der(w) = (pm - (P/CoB))/M;
+    der(w) = ((pm - P)/CoB)/M;
   end if;
   [p.ir; p.ii] = -CoB*[sin(delta), cos(delta); -cos(delta), sin(delta)]*[id; iq];
   [p.vr; p.vi] = [sin(delta), cos(delta); -cos(delta), sin(delta)]*[vd; vq];
   -P = p.vr*p.ir + p.vi*p.ii;
   -Q = p.vi*p.ir - p.vr*p.ii;
-  pm0 = pm00;
+  pm0 = CoB*pm00 "pu, system base";
   annotation (
     Icon(coordinateSystem(extent={{-100,-100},{100,100}}, initialScale=0.1),
         graphics={

--- a/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
@@ -84,55 +84,64 @@ partial model baseMachine
   Real id(start=id0) "d-axis currrent (pu)";
   Real iq(start=iq0) "q-axis current (pu)";
 protected
+  Real pe(start=pm00) "electrical power transmitted through the air-gap";
   parameter Real w_b=2*pi*fn "Base frequency in rad/s";
-  parameter Real CoB=Sn/S_b "From machine base to system base";
+  // Define multiplicative transforms to go from one pu-base to another:
+  parameter Real S_SBtoMB=S_b/Sn "S(system base) -> S(machine base)";
+  parameter Real I_MBtoSB=(Sn*V_b)/(S_b*Vn) "I(machine base) -> I(system base)";
+  parameter Real V_MBtoSB=Vn/V_b "V(machine base) -> V(system base)";
+  parameter Real Z_MBtoSB=(S_b*Vn^2)/(Sn*V_b^2)
+    "Z(machine base) -> S(system base)";
 
   // Initialize stator quantities (system base):
-  //protected
   parameter Real p0=P_0/S_b
     "Initial active power generation in pu (system base)";
   parameter Real q0=Q_0/S_b
     "Initial reactive power generation in pu (system base)";
   parameter Complex Vt0=CM.fromPolar(V_0, SI.Conversions.from_deg(angle_0))
-    "conj.";
-  parameter Complex S0(re=p0, im=-q0) "conj.";
-  parameter Complex I0=S0/(CM.conj(Vt0));
-  parameter Real vr0=CM.real(Vt0) "Initialization (pu)";
-  parameter Real vi0=CM.imag(Vt0) "Initialization (pu)";
-  parameter Real ir0=-CM.real(I0) "Initialization (pu)";
-  parameter Real ii0=-CM.imag(I0) "Initialization (pu)";
+    "Init. val., conjugate";
+  parameter Complex S0(re=p0, im=-q0) "Init. val., conjugate";
+  parameter Complex I0=S0/(CM.conj(Vt0)) "Init. val., conjugate";
+  parameter Real vr0=CM.real(Vt0) "Init. val.";
+  parameter Real vi0=CM.imag(Vt0) "Init. val.";
+  parameter Real ir0=-CM.real(I0) "Init. val.";
+  parameter Real ii0=-CM.imag(I0) "Init. val.";
 
-  // Initialize DQ-quantities (machine base)
-
+  // Initialize DQ-quantities (pu, machine base)
   parameter Real xq0 "used for setting the initial rotor angle";
-  parameter SI.Angle delta0=CM.arg(Vt0 + (ra + CM.j*xq0)*(I0/CoB))
-    "Initial rotor angle";
-  parameter Complex Vdq0=Vt0*CM.fromPolar(1, -delta0 + (pi/2));
-  parameter Complex Idq0=I0/CoB*CM.fromPolar(1, -delta0 + (pi/2));
-  parameter Real vd0=CM.real(Vdq0) "Initialization (pu, machine base)";
-  parameter Real vq0=CM.imag(Vdq0) "Initialization (pu, machine base)";
-  parameter Real id0=CM.real(Idq0) "Initialization (pu, machine base)";
-  parameter Real iq0=CM.imag(Idq0) "Initialization (pu, machine base)";
-  parameter Real pm00=(vq0 + ra*iq0)*iq0 + (vd0 + ra*id0)*id0
-    "Initialization (pu, machine base";
+  parameter SI.Angle delta0=CM.arg((Vt0 + ((ra + CM.j*xq0)*Z_MBtoSB*I0)))
+    "Init. val. rotor angle";
+  parameter Complex Vdq0=Vt0*CM.fromPolar(1/V_MBtoSB, (-delta0 + (pi/2)))
+    "Init. val (pu, machine base)";
+  parameter Complex Idq0=I0*CM.fromPolar(1/I_MBtoSB, (-delta0 + (pi/2)))
+    "(pu, machine base)";
+  parameter Real vd0=CM.real(Vdq0) "Init. val.";
+  parameter Real vq0=CM.imag(Vdq0) "Init. val.";
+  parameter Real id0=CM.real(Idq0) "Init. val.";
+  parameter Real iq0=CM.imag(Idq0) "Init. val.";
+
+  parameter Real pm00=((vq0 + ra*iq0)*iq0 + (vd0 + ra*id0)*id0)/S_SBtoMB
+    "Init. val. (pu, system base)";
 initial equation
   w = 1;
-  der(delta) = 0;
   delta = delta0;
 equation
   v = sqrt(p.vr^2 + p.vi^2);
   anglev = atan2(p.vi, p.vr);
   der(delta) = w_b*(w - 1);
   if D > Modelica.Constants.eps then
-    der(w) = ((pm - P)/CoB - D*(w - 1))/M;
+    der(w) = (pm*S_SBtoMB - pe - D*(w - 1))/M;
   else
-    der(w) = ((pm - P)/CoB)/M;
+    der(w) = (pm*S_SBtoMB - pe)/M;
   end if;
-  [p.ir; p.ii] = -CoB*[sin(delta), cos(delta); -cos(delta), sin(delta)]*[id; iq];
-  [p.vr; p.vi] = [sin(delta), cos(delta); -cos(delta), sin(delta)]*[vd; vq];
-  -P = p.vr*p.ir + p.vi*p.ii;
-  -Q = p.vi*p.ir - p.vr*p.ii;
-  pm0 = CoB*pm00 "pu, system base";
+  [p.ir; p.ii] = -[sin(delta), cos(delta); -cos(delta), sin(delta)]*[id; iq]*
+    I_MBtoSB;
+  [p.vr; p.vi] = [sin(delta), cos(delta); -cos(delta), sin(delta)]*[vd; vq]*
+    V_MBtoSB;
+  P = -p.vr*p.ir - p.vi*p.ii;
+  Q = -p.vi*p.ir + p.vr*p.ii;
+  pe = (vq + ra*iq)*iq + (vd + ra*id)*id "pu, machine base";
+  pm0 = pm00 "pu, system base";
   annotation (
     Icon(coordinateSystem(extent={{-100,-100},{100,100}}, initialScale=0.1),
         graphics={

--- a/OpenIPSL/Electrical/Machines/PSAT/Order2.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/Order2.mo
@@ -1,19 +1,14 @@
 within OpenIPSL.Electrical.Machines.PSAT;
 model Order2 "Second Order Synchronous Machine with Inputs and Outputs"
-  extends BaseClasses.baseMachine(
-    vf(start=vf00),
-    vf0(start=vf00),
-    xq0=x1d);
+  extends BaseClasses.baseMachine(vf(start=vf00), xq0=x1d);
 protected
   parameter Real K=1/(ra^2 + x1d^2) "a constant for scaling";
   parameter Real c1=ra*K "scaled ra";
   parameter Real c2=x1d*K "scaled x'd";
   parameter Real c3=x1d*K "scaled x'd";
   parameter Real vf00=vq0 + ra*iq0 + x1d*id0 "Initialization";
-initial equation
-  vf0 = vf00;
 equation
-  id = -c1*vd + c3*vq + vf*c3;
+  id = -c1*vd - c3*vq + vf*c3;
   iq = c2*vd - c1*vq + vf*c1;
   vf0 = vf00;
   annotation (Documentation(info="<html> 

--- a/OpenIPSL/Examples/Controls/PSAT/OEL/AVRTypeII_OEL_Test.mo
+++ b/OpenIPSL/Examples/Controls/PSAT/OEL/AVRTypeII_OEL_Test.mo
@@ -32,17 +32,18 @@ model AVRTypeII_OEL_Test
     T0=5,
     xd=order4.xd,
     xq=order4.xq,
-    if_lim=2.15)
-    annotation (Placement(transformation(extent={{-20,24},{-40,44}})));
+    if_lim=1.15,
+    S_mb=order4.Sn)
+    annotation (Placement(transformation(extent={{-18,26},{-38,46}})));
   Modelica.Blocks.Math.Add add
     annotation (Placement(transformation(extent={{-52,30},{-62,40}})));
   Modelica.Blocks.Sources.Ramp ramp(
     duration=20,
     startTime=1,
-    height=-0.1) annotation (Placement(transformation(
+    height=0.1) annotation (Placement(transformation(
         extent={{5,-5},{-5,5}},
         rotation=0,
-        origin={-37,59})));
+        origin={-41,55})));
 equation
   connect(order4.pm0, order4.pm) annotation (Line(points={{-43,-11},{-43,-16},{
           -60,-16},{-60,-5},{-47,-5}}, color={0,0,127}));
@@ -53,21 +54,25 @@ equation
   connect(exciter_Type_II.vf0, order4.vf0) annotation (Line(points={{-80,16},{-80,
           16},{-80,11},{-43,11}}, color={0,0,127}));
   connect(exciter_Type_II.vref0, oXL.v_ref0) annotation (Line(points={{-80,40},
-          {-80,40},{-80,48},{-30,48},{-30,45.2}},color={0,0,127}));
-  connect(oXL.v, order4.v) annotation (Line(points={{-20.8,40},{-12,40},{-12,3},
+          {-80,40},{-80,72},{-28,72},{-28,47.2}},color={0,0,127}));
+  connect(oXL.v, order4.v) annotation (Line(points={{-18.8,42},{-12,42},{-12,3},
           {-24,3}}, color={0,0,127}));
-  connect(order4.P, oXL.p) annotation (Line(points={{-24,-3},{-14,-3},{-14,36},
-          {-20.8,36}}, color={0,0,127}));
-  connect(order4.Q, oXL.q) annotation (Line(points={{-24,-7},{-16,-7},{-16,32},
-          {-20.8,32}}, color={0,0,127}));
+  connect(order4.P, oXL.p) annotation (Line(points={{-24,-3},{-14,-3},{-14,38},
+          {-18.8,38}},color={0,0,127}));
+  connect(order4.Q, oXL.q) annotation (Line(points={{-24,-7},{-16,-7},{-16,34},
+          {-18.8,34}},color={0,0,127}));
   connect(exciter_Type_II.v, order4.v) annotation (Line(points={{-68,22},{-20,
           22},{-20,3},{-24,3}}, color={0,0,127}));
   connect(exciter_Type_II.vref, add.y) annotation (Line(points={{-68,34},{-66,
           34},{-66,35},{-62.5,35}}, color={0,0,127}));
-  connect(add.u2, oXL.v_ref) annotation (Line(points={{-51,32},{-46,32},{-46,34},
-          {-40.4,34}}, color={0,0,127}));
-  connect(ramp.y, add.u1) annotation (Line(points={{-42.5,59},{-42.5,48.5},{-51,
-          48.5},{-51,38}}, color={0,0,127}));
-  annotation (Documentation, Diagram(coordinateSystem(preserveAspectRatio=false,
-          extent={{-100,-100},{100,100}})));
+  connect(add.u2, oXL.v_ref) annotation (Line(points={{-51,32},{-46,32},{-46,36},
+          {-38.4,36}}, color={0,0,127}));
+  connect(ramp.y, add.u1) annotation (Line(points={{-46.5,55},{-46.5,54.5},{-51,
+          54.5},{-51,38}}, color={0,0,127}));
+  annotation (
+    Documentation,
+    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
+            100,100}})),
+    experiment(StopTime=50),
+    __Dymola_experimentSetupOutput);
 end AVRTypeII_OEL_Test;


### PR DESCRIPTION
#PSAT machine model 2: Corrects a nasty bug of commit 4eb03d4 (which made corresponding examples not runnable) as well as some old problems of different bases of all PSAT machine models, which were mishandled since very early commits. Also, fixes the PSAT OEL to have correct behavior.