### PR TITLE
Machine base power rating change

### DIFF
--- a/OpenIPSL/Electrical/Machines/PSSE/GENCLS.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/GENCLS.mo
@@ -16,7 +16,7 @@ model GENCLS
     ii(start=ii0)) annotation (Placement(transformation(
         origin={100,0},
         extent={{-10,-10},{10,10}})));
-  parameter SI.ApparentPower M_b(displayUnit="MVA") "Machine base power rating"
+  parameter SI.ApparentPower M_b(start = 100e6, displayUnit="MVA") "Machine base power rating"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time H=0 "Inertia constant (s)"
     annotation (Dialog(group="Machine parameters"));

--- a/OpenIPSL/Examples/SMIBpartial.mo
+++ b/OpenIPSL/Examples/SMIBpartial.mo
@@ -22,7 +22,7 @@ partial model SMIBpartial "SMIB system with one load"
     G=0,
     B=0) annotation (Placement(transformation(extent={{54,-34},{66,-26}})));
   OpenIPSL.Electrical.Machines.PSSE.GENCLS gENCLS(
-    M_b=100,
+    M_b,
     D=0,
     angle_0=0,
     X_d=0.2,


### PR DESCRIPTION
I edited the start value of the GENCLS machine base power rating model to 100e6 as a start value (when you simulate it there is a translation warning about this). Then I edited the SMIBpartial model to have this as a starting value. I also used sublime text rather than dymola in order to make sure that graphics would not be changed or messed with.