### PR TITLE
Remove hard coded and doubly defined start values for w and delta

### DIFF
--- a/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
@@ -118,9 +118,7 @@ protected
 
   parameter SI.PerUnit pm00=((vq0 + ra*iq0)*iq0 + (vd0 + ra*id0)*id0)/S_SBtoMB
     "Init. val. (pu, system base)";
-initial equation
-  w = 1;
-  delta = delta0;
+
 equation
   v = sqrt(p.vr^2 + p.vi^2);
   anglev = atan2(p.vi, p.vr);


### PR DESCRIPTION
Those hard coded lines make it impossible to change the start speed of the generator. Something needed in run-up tests etc.  In addition, delta was initialised twice. 
