### PR TITLE
Explains the PSAT AVR models mix up

### DIFF
--- a/OpenIPSL/Electrical/Controls/PSAT/AVR/AVRTypeI.mo
+++ b/OpenIPSL/Electrical/Controls/PSAT/AVR/AVRTypeI.mo
@@ -10,8 +10,8 @@ model AVRTypeI "PSAT AVR Type 1"
         origin={110,0}), iconTransformation(extent={{100,-20},{140,20}})));
   Modelica.Blocks.Interfaces.RealInput vref
     "Reference generator terminal voltage [pu]" annotation (Placement(
-        transformation(extent={{-140,40},{-100,80}}), iconTransformation(extent
-          ={{-140,40},{-100,80}})));
+        transformation(extent={{-140,40},{-100,80}}), iconTransformation(extent=
+           {{-140,40},{-100,80}})));
   parameter SI.PerUnit vrmax=7.57 "Maximum regulator voltage";
   parameter SI.PerUnit vrmin=0 "Minimum regulator voltage";
   parameter Real K0=7.04 "Regulator gain, [pu/pu]";
@@ -123,14 +123,13 @@ equation
           lineColor={0,0,255},
           textString="vref0")}),
     Documentation(info="<html>
-<table cellspacing=\"1\" cellpadding=\"1\" border=\"1\">
-<tr>
+<table cellspacing=\"1\" cellpadding=\"1\" border=\"1\"><tr>
 <td><p>Reference</p></td>
-<td><p>AVR Type II, PSAT Manual 2.1.8</p></td>
+<td><p>AVR Type I, PSAT Manual 2.1.8</p></td>
 </tr>
 <tr>
 <td><p>Last update</p></td>
-<td>September 2015</td>
+<td><p>September 2015</p></td>
 </tr>
 <tr>
 <td><p>Author</p></td>
@@ -141,5 +140,12 @@ equation
 <td><p><a href=\"mailto:luigiv@kth.se\">luigiv@kth.se</a></p></td>
 </tr>
 </table>
+<span style=\"color: #ff0000\">
+<h5>WARNING</h5>
+<p>The PSAT Toolbox  called this model &quot;AVR Type I&quot;
+ (see <a href=\"modelica://OpenIPSL.UsersGuide.References\">[Milano2013], section 18.3.1</a>) 
+ when it actually is the &quot;IEEE <b>Type II</b>&quot;
+ (see <a href=\"modelica://OpenIPSL.UsersGuide.References\">[Milano2010], chapter 16.2.2</a>).</p>
+</span>
 </html>"));
 end AVRTypeI;

--- a/OpenIPSL/Electrical/Controls/PSAT/AVR/AVRTypeII.mo
+++ b/OpenIPSL/Electrical/Controls/PSAT/AVR/AVRTypeII.mo
@@ -10,8 +10,8 @@ model AVRTypeII "PSAT AVR Type 2"
         origin={110,0}), iconTransformation(extent={{100,-20},{140,20}})));
   Modelica.Blocks.Interfaces.RealInput vref
     "Reference generator terminal voltage [pu]" annotation (Placement(
-        transformation(extent={{-140,40},{-100,80}}), iconTransformation(extent
-          ={{-140,40},{-100,80}})));
+        transformation(extent={{-140,40},{-100,80}}), iconTransformation(extent=
+           {{-140,40},{-100,80}})));
   parameter SI.PerUnit vrmin=-5 "Minimum regulator voltage";
   parameter SI.PerUnit vrmax=5 "Maximum regulator voltage";
   parameter Real Ka=100 "Amplifier gain [pu/pu]";
@@ -175,5 +175,12 @@ equation
 <td><p><a href=\"mailto:luigiv@kth.se\">luigiv@kth.se</a></p></td>
 </tr>
 </table>
+<span style=\"color: #ff0000\">
+<h5>WARNING</h5>
+<p>The PSAT Toolbox  called this model &quot;AVR Type II&quot;
+ (see <a href=\"modelica://OpenIPSL.UsersGuide.References\">[Milano2013], section 18.3.2</a>) 
+ when it actually is the &quot;IEEE <b>Type I</b>&quot;
+ (see <a href=\"modelica://OpenIPSL.UsersGuide.References\">[Milano2010], chapter 16.2.1</a>).</p>
+</span>
 </html>"));
 end AVRTypeII;

--- a/OpenIPSL/Electrical/Controls/PSAT/AVR/AVRtypeIII.mo
+++ b/OpenIPSL/Electrical/Controls/PSAT/AVR/AVRtypeIII.mo
@@ -1,5 +1,5 @@
 within OpenIPSL.Electrical.Controls.PSAT.AVR;
-model AVRtypeIII
+model AVRtypeIII "PSAT AVR Type 3"
   parameter SI.PerUnit vfmax=5;
   parameter SI.PerUnit vfmin=-5;
   parameter SI.PerUnit K0=20 "regulator gain";
@@ -97,6 +97,8 @@ equation
 <td><p><a href=\"mailto:luigiv@kth.se\">luigiv@kth.se</a></p></td>
 </tr>
 </table>
+<p>See also <a href=\"modelica://OpenIPSL.UsersGuide.References\">[Milano2013], section 18.3.3</a> 
+ or <a href=\"modelica://OpenIPSL.UsersGuide.References\">[Milano2010], chapter 16.2.3</a>.</p>
 </html>"),
     Diagram(coordinateSystem(extent={{-120,-120},{120,120}})));
 end AVRtypeIII;

--- a/OpenIPSL/UsersGuide/References.mo
+++ b/OpenIPSL/UsersGuide/References.mo
@@ -4,6 +4,14 @@ model References "References"
   annotation (Documentation(info="<html>
 <table cellspacing=\"0\" cellpadding=\"2\" border=\"0\">
 <tr>
+<td>[Milano2010]</td>
+<td>Federico Milano
+        &quot;Power System Modelling and Scripting&quot;,
+        Springer 2010, 
+        <a href=\"https://www.springer.com/gp/book/9783642136689\">ISBN 978-3-642-13668-9</a>
+</td>
+</tr>
+<tr>
 <td>[Milano2013]</td>
 <td>Federico Milano
         &quot;Power System Analysis Toolbox&quot;,


### PR DESCRIPTION
Fixes #164: Adds a warning and also reference to F. Milano's book 