### PR TITLE
Fix gencls

### DIFF
--- a/OpenIPSL/Electrical/Buses/Bus.mo
+++ b/OpenIPSL/Electrical/Buses/Bus.mo
@@ -15,7 +15,7 @@ model Bus "Bus model (2014/03/10)"
         extent={{-10.0,-10.0},{10.0,10.0}}),
       iconTransformation(
         extent={{-10,-10},{10,10}})));
-  Real V(start=v_0) "Bus voltage magnitude (pu)";
+  SI.PerUnit V(start=v_0) "Bus voltage magnitude";
   Modelica.SIunits.Conversions.NonSIunits.Angle_deg angle(start=angle_0)
     "Bus voltage angle";
 equation

--- a/OpenIPSL/Electrical/Machines/PSSE/GENCLS.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/GENCLS.mo
@@ -59,7 +59,7 @@ equation
     der(omega) = (P_0/S_b - P - D*omega)/(2*H);
   else
     der(delta) = 0;
-    omega = 0;
+    der(omega) = 0;
   end if;
   // d-q voltage and current equations
   der(eq) = 0 "Classical model assumes constant emf";

--- a/OpenIPSL/Examples/BaseClasses/SMIB.mo
+++ b/OpenIPSL/Examples/BaseClasses/SMIB.mo
@@ -47,7 +47,7 @@ partial model SMIB "SMIB - Single Machine Infinte Base system with one load"
     annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   inner OpenIPSL.Electrical.SystemBase SysData(S_b = 100e6, fn = 50)
     annotation (Placement(transformation(extent={{-100,80},{-60,100}})));
-  OpenIPSL.Electrical.Buses.Bus LOAD
+  OpenIPSL.Electrical.Buses.Bus LOAD(v_0=constantLoad.v_0, angle_0=constantLoad.angle_0)
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   OpenIPSL.Electrical.Buses.Bus GEN2
     annotation (Placement(transformation(extent={{70,-10},{90,10}})));


### PR DESCRIPTION
This update should fix some initialization problems with SMIB system and the over-specified equation for omega. This might address issues #170 and #229 

(fixes #170 and fixes #229)