### PR TITLE
Add an initial speed deviation and remove superfluous initial equationns

### DIFF
--- a/OpenIPSL/Electrical/Machines/PSSE/BaseClasses/baseMachine.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/BaseClasses/baseMachine.mo
@@ -47,14 +47,15 @@ partial model baseMachine
     annotation (Dialog(group="Machine parameters"));
   parameter SI.PerUnit R_a=0 "Armature resistance"
     annotation (Dialog(group="Machine parameters"));
-  //Initialization
+  parameter SI.PerUnit w0(min=-1+C.eps)=0 "Initial speed deviation from nominal"
+    annotation (Dialog(group="Initialization"));
   OpenIPSL.Interfaces.PwPin p(
     vr(start=vr0),
     vi(start=vi0),
     ir(start=ir0),
     ii(start=ii0))
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
-  RealOutput SPEED(start=0) "Machine speed deviation from nominal (pu)"
+  RealOutput SPEED "Machine speed deviation from nominal (pu)"
     annotation (Placement(transformation(extent={{100,60},{120,80}})));
   RealInput PMECH "Turbine mechanical power (pu, machine base)"
     annotation (Placement(transformation(extent={{-140,30},{-100,70}})));
@@ -78,7 +79,7 @@ partial model baseMachine
         origin={110,-90}), iconTransformation(
         extent={{-10,-10},{10,10}},
         origin={110,-90})));
-  SI.PerUnit w(start=0) "Machine speed deviation (pu)";
+  SI.PerUnit w(start=w0) "Machine speed deviation (pu)";
   SI.Angle delta "Rotor angle";
   SI.PerUnit Vt(start=v_0) "Bus voltage magnitude (pu)";
   SI.Angle anglev(start=angle_0rad) "Bus voltage angle";

--- a/OpenIPSL/Electrical/Machines/PSSE/GENROE.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/GENROE.mo
@@ -12,11 +12,9 @@ model GENROE "ROUND ROTOR GENERATOR MODEL (EXPONENTIAL SATURATION)"
   import OpenIPSL.NonElectrical.Functions.SE_exp;
   import Modelica.ComplexMath.j;
   extends BaseClasses.baseMachine(
-    w(start=0),
     EFD(start=efd0),
     XADIFD(start=efd0),
     PMECH(start=pm0),
-    ANGLE(start=delta0),
     delta(start=delta0),
     id(start=id0),
     iq(start=iq0),
@@ -125,8 +123,6 @@ initial equation
   der(Epq) = 0;
   der(PSIkd) = 0;
   der(PSIkq) = 0;
-  delta = delta0;
-  w = 0;
 equation
   //Interfacing outputs with the internal variables
   XADIFD = XadIfd;
@@ -158,7 +154,6 @@ equation
   //change sign for PSIppq 3/3
   ud = (-PSIq) - R_a*id;
   uq = PSId - R_a*iq;
-  //flow
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
             100}}), graphics={Text(

--- a/OpenIPSL/Electrical/Machines/PSSE/GENROU.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/GENROU.mo
@@ -12,9 +12,7 @@ model GENROU "ROUND ROTOR GENERATOR MODEL (QUADRATIC SATURATION)"
   import Modelica.ComplexMath.j;
   import OpenIPSL.NonElectrical.Functions.SE;
   extends BaseClasses.baseMachine(
-    w(start=0),
     XADIFD(start=efd0),
-    ANGLE(start=delta0),
     delta(start=delta0),
     id(start=id0),
     iq(start=iq0),
@@ -123,8 +121,6 @@ initial equation
   der(Epq) = 0;
   der(PSIkd) = 0;
   der(PSIkq) = 0;
-  delta = delta0;
-  w = 0;
 equation
   //Interfacing outputs with the internal variables
   XADIFD = XadIfd;
@@ -156,7 +152,6 @@ equation
   //change sign for PSIppq 3/3
   ud = (-PSIq) - R_a*id;
   uq = PSId - R_a*iq;
-  //flow
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
             100}}), graphics={Text(

--- a/OpenIPSL/Electrical/Machines/PSSE/GENSAE.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/GENSAE.mo
@@ -13,11 +13,9 @@ model GENSAE "SALIENT POLE GENERATOR MODEL (EXPONENTIAL SATURATION)"
   import Modelica.ComplexMath.j;
   //Extending machine base
   extends BaseClasses.baseMachine(
-    w(start=0),
     EFD(start=efd0),
     XADIFD(start=efd0),
     PMECH(start=pm0),
-    ANGLE(start=delta0),
     delta(start=delta0),
     id(start=id0),
     iq(start=iq0),
@@ -90,8 +88,6 @@ initial equation
   der(Epq) = 0;
   der(PSIkd) = 0;
   der(PSIppq) = 0;
-  delta = delta0;
-  w = 0;
 equation
   //Interfacing outputs with the internal variables
   XADIFD = XadIfd;
@@ -119,7 +115,6 @@ equation
   Te = PSId*iq - PSIq*id;
   ud = (-PSIq) - R_a*id;
   uq = PSId - R_a*iq;
-  //flow, changed from machine base to system bas
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
             100}}), graphics={Text(

--- a/OpenIPSL/Electrical/Machines/PSSE/GENSAL.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/GENSAL.mo
@@ -13,11 +13,9 @@ model GENSAL "SALIENT POLE GENERATOR MODEL (QUADRATIC SATURATION ON D-AXIS)"
   import Modelica.ComplexMath.j;
   //Extending machine base class
   extends BaseClasses.baseMachine(
-    w(start=0),
     EFD(start=efd0),
     XADIFD(start=efd0),
     PMECH(start=pm0),
-    ANGLE(start=delta0),
     delta(start=delta0),
     id(start=id0),
     iq(start=iq0),
@@ -82,8 +80,6 @@ initial equation
   der(Epq) = 0;
   der(PSIkd) = 0;
   der(PSIppq) = 0;
-  delta = delta0;
-  w = 0;
 equation
   //Interfacing outputs with the internal variables
   XADIFD = XadIfd;
@@ -105,7 +101,6 @@ equation
   Te = PSId*iq - PSIq*id;
   ud = (-PSIq) - R_a*id;
   uq = PSId - R_a*iq;
-  //flow, changed from machine base to system bas
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
             100}}), graphics={Text(


### PR DESCRIPTION
This allows the generator models to be used in application where start speeds other than 1 pu are required (e.g., run up and synchronisation of a generator)
