### PR TITLE
Clean up description strings wrt to units

### DIFF
--- a/OpenIPSL/Electrical/Banks/PSSE/CSVGN1.mo
+++ b/OpenIPSL/Electrical/Banks/PSSE/CSVGN1.mo
@@ -14,7 +14,7 @@ model CSVGN1 "STATC SHUNT COMPENSATOR MODEL"
   parameter SI.Conversions.NonSIunits.Angle_deg angle_0=0 "Initial voltage angle"
     annotation (Dialog(group="Power flow data"));
   parameter SI.PerUnit ra=0 "amature resistance" annotation (Dialog(group="Plant parameters", enable = false));
-  parameter SI.PerUnit x1d=9999 "d-axis transient reactance, pu, should be set to 9999" annotation (Dialog(group="Plant parameters", enable = false));
+  parameter SI.PerUnit x1d=9999 "d-axis transient reactance, should be set to 9999" annotation (Dialog(group="Plant parameters", enable = false));
   parameter Real K=1 annotation (Dialog(group="Device parameters"));
   parameter SI.Time T1=0 annotation (Dialog(group="Device parameters"));
   parameter SI.Time T2=0 annotation (Dialog(group="Device parameters"));
@@ -85,8 +85,8 @@ model CSVGN1 "STATC SHUNT COMPENSATOR MODEL"
   Modelica.Blocks.Math.Add add2(k2=-1)
     annotation (Placement(transformation(extent={{-78,-40},{-58,-20}})));
 protected
-  parameter SI.PerUnit p0=P_0/S_b "Active power pu on system base";
-  parameter SI.PerUnit q0=Q_0/S_b "Reactive power pu on system base";
+  parameter SI.PerUnit p0=P_0/S_b "Active power (system base)";
+  parameter SI.PerUnit q0=Q_0/S_b "Reactive power (system base)";
   parameter SI.Angle anglev_rad=SI.Conversions.from_deg(angle_0);
   parameter SI.PerUnit Y0=q0/(v_0*v_0) "Capacitor output";
   parameter SI.PerUnit vr0=v_0*cos(anglev_rad) "Initialization";

--- a/OpenIPSL/Electrical/Banks/PSSE/SVC/SVC.mo
+++ b/OpenIPSL/Electrical/Banks/PSSE/SVC/SVC.mo
@@ -41,11 +41,11 @@ model SVC "On bus 10106 & 10114"
   parameter SI.PerUnit Vref "Reference voltage";
   parameter SI.PerUnit Bref "Reference susceptance";
   parameter Real K=150 "Steady-state gain";
-  parameter Real T1 "Time constant (s)";
-  parameter Real T2 "Time constant (s)";
-  parameter Real T3 "Time constant (s)";
-  parameter Real T4 "Time constant (s)";
-  parameter Real T5=0.03 "Time constant of thyristor bridge (s)";
+  parameter SI.Time T1 "Time constant";
+  parameter SI.Time T2 "Time constant";
+  parameter SI.Time T3 "Time constant";
+  parameter SI.Time T4 "Time constant";
+  parameter SI.Time T5=0.03 "Time constant of thyristor bridge";
   parameter SI.PerUnit Vmax;
   parameter SI.PerUnit Vmin;
   parameter SI.PerUnit Vov=0.5 "Override voltage";

--- a/OpenIPSL/Electrical/Banks/PSSE/SVC/SVC.mo
+++ b/OpenIPSL/Electrical/Banks/PSSE/SVC/SVC.mo
@@ -1,7 +1,7 @@
 within OpenIPSL.Electrical.Banks.PSSE.SVC;
 model SVC "On bus 10106 & 10114"
   OpenIPSL.Interfaces.PwPin VIB
-    "Voltage signal connected to stepdown transformer (pu)"
+    "Voltage signal connected to stepdown transformer"
     annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
   Modelica.Blocks.Sources.Constant imSetPoint(k=Vref)
     annotation (Placement(transformation(extent={{-76,20},{-64,32}})));
@@ -38,8 +38,8 @@ model SVC "On bus 10106 & 10114"
     annotation (Placement(transformation(extent={{-20,-38},{-10,-28}})));
   Modelica.Blocks.Math.Gain imGain(k=1/Sbase)
     annotation (Placement(transformation(extent={{60,-36},{72,-24}})));
-  parameter SI.PerUnit Vref "Reference voltage (pu)";
-  parameter SI.PerUnit Bref "Reference susceptance (pu)";
+  parameter SI.PerUnit Vref "Reference voltage";
+  parameter SI.PerUnit Bref "Reference susceptance";
   parameter Real K=150 "Steady-state gain";
   parameter Real T1 "Time constant (s)";
   parameter Real T2 "Time constant (s)";
@@ -48,7 +48,7 @@ model SVC "On bus 10106 & 10114"
   parameter Real T5=0.03 "Time constant of thyristor bridge (s)";
   parameter SI.PerUnit Vmax;
   parameter SI.PerUnit Vmin;
-  parameter SI.PerUnit Vov=0.5 "Override voltage (pu)";
+  parameter SI.PerUnit Vov=0.5 "Override voltage";
   parameter SI.ApparentPower Sbase(displayUnit="MVA") "Base power of the bus";
   parameter Real init_SVC_Leadlag "Initial value";
   parameter Real init_SVC_Lag "Initial value";

--- a/OpenIPSL/Electrical/Banks/PSSE/Shunt.mo
+++ b/OpenIPSL/Electrical/Banks/PSSE/Shunt.mo
@@ -1,7 +1,7 @@
 within OpenIPSL.Electrical.Banks.PSSE;
 model Shunt
-  parameter SI.PerUnit G "(pu) on system base";
-  parameter SI.PerUnit B "(pu) on system base";
+  parameter SI.PerUnit G "Conductance (system base)";
+  parameter SI.PerUnit B "Susceptance (system base)";
   Complex I;
   Complex V;
   SI.PerUnit v;

--- a/OpenIPSL/Electrical/Banks/PwCapacitorBank.mo
+++ b/OpenIPSL/Electrical/Banks/PwCapacitorBank.mo
@@ -3,8 +3,8 @@ model PwCapacitorBank "Capacitor Bank with Bank.2013"
   OpenIPSL.Interfaces.PwPin p
     annotation (Placement(transformation(extent={{-10,90},{10,110}})));
   parameter Integer nsteps "number of steps";
-  parameter SI.PerUnit G=0 "Active power losses (pu)";
-  parameter SI.PerUnit B=0 "Reactive power (pu)";
+  parameter SI.PerUnit G=0 "Active power losses";
+  parameter SI.PerUnit B=0 "Reactive power";
 equation
   p.vr = (p.ir*G + p.ii*B)/(G*G + B*B);
   p.vi = ((-p.ir*B) + p.ii*G)/(G*G + B*B);

--- a/OpenIPSL/Electrical/Banks/PwCapacitorBankWithModification.mo
+++ b/OpenIPSL/Electrical/Banks/PwCapacitorBankWithModification.mo
@@ -4,8 +4,8 @@ model PwCapacitorBankWithModification "Capacitor Bank with Bank modification at 
   OpenIPSL.Interfaces.PwPin p
     annotation (Placement(transformation(extent={{-10,90},{10,110}})));
   parameter Integer nsteps "Number of steps";
-  parameter SI.PerUnit Go "Active power losses (pu) in each element";
-  parameter SI.PerUnit Bo "Reactive power (pu) in each element";
+  parameter SI.PerUnit Go "Active power losses in each element";
+  parameter SI.PerUnit Bo "Reactive power in each element";
   parameter SI.Time t1 "Time for bank Modification";
   parameter Integer nmod "Number of step to switch on/off (+/-)";
   SI.PerUnit G;

--- a/OpenIPSL/Electrical/Banks/PwShunt.mo
+++ b/OpenIPSL/Electrical/Banks/PwShunt.mo
@@ -3,11 +3,11 @@ model PwShunt "Thyristor controlled Shunt reactor/capacitor"
   OpenIPSL.Interfaces.PwPin p
     annotation (Placement(transformation(extent={{-10,90},{10,110}})));
   Modelica.Blocks.Interfaces.RealInput Q
-    "Reactive power produced by the shunt (pu)"
+    "Reactive power produced by the shunt [pu]"
     annotation (Placement(transformation(extent={{-120,-10},{-100,10}})));
   parameter SI.Frequency fn=50 "Frequency rating";
-  SI.PerUnit c "Capacitance in (pu)";
-  SI.PerUnit l "Inductance in (pu)";
+  SI.PerUnit c "Capacitance";
+  SI.PerUnit l "Inductance";
   SI.PerUnit v;
   SI.Angle anglev;
   SI.PerUnit i;

--- a/OpenIPSL/Electrical/Banks/Simulink/Shunt.mo
+++ b/OpenIPSL/Electrical/Banks/Simulink/Shunt.mo
@@ -5,7 +5,7 @@ model Shunt "Shunt Inductor or Capacitor"
   parameter SI.ReactivePower Qnom(displayUnit="Mvar")
     "Reactive power produced by the shunt at 1 pu voltage, (negative for inductive charge, positive for capacitive charge)";
   parameter SI.ApparentPower Sbase(displayUnit="MVA") "Base power of the system";
-  parameter SI.PerUnit X=Sbase/(-Qnom) "Reactance (pu)";
+  parameter SI.PerUnit X=Sbase/(-Qnom) "Reactance";
   SI.PerUnit Q "Consumed power";
   SI.PerUnit v;
 equation

--- a/OpenIPSL/Electrical/Branches/PSAT/PhaseShiftingTransformer.mo
+++ b/OpenIPSL/Electrical/Branches/PSAT/PhaseShiftingTransformer.mo
@@ -57,9 +57,9 @@ model PhaseShiftingTransformer "Phase Shifting Transformer (PST)"
     annotation (Dialog(group="Transformer parameters"));
   parameter SI.Voltage Vn(displayUnit="kV")=40e3 "Voltage rating"
     annotation (Dialog(group="Transformer parameters"));
-  parameter SI.PerUnit rT=0.01 "Resistance (pu, transformer base)"
+  parameter SI.PerUnit rT=0.01 "Resistance (transformer base)"
     annotation (Dialog(group="Transformer parameters"));
-  parameter SI.PerUnit xT=0.1 "Reactance (pu, transformer base)"
+  parameter SI.PerUnit xT=0.1 "Reactance (transformer base)"
     annotation (Dialog(group="Transformer parameters"));
   parameter Real m=1.0 "Optional fixed tap ratio"
     annotation (Dialog(group="Transformer parameters"));

--- a/OpenIPSL/Electrical/Branches/PSAT/ThreeWindingTransformer.mo
+++ b/OpenIPSL/Electrical/Branches/PSAT/ThreeWindingTransformer.mo
@@ -15,17 +15,17 @@ model ThreeWindingTransformer
     annotation (Dialog(group="Transformer parameters"));
   parameter SI.Voltage Vn(displayUnit="kV")=40e3 "Voltage rating for transformer"
     annotation (Dialog(group="Transformer parameters"));
-  parameter SI.PerUnit r12=0.01 "Resistance of the branch 1-2 (pu, transformer base)"
+  parameter SI.PerUnit r12=0.01 "Resistance of the branch 1-2 (transformer base)"
     annotation (Dialog(group="Transformer parameters"));
-  parameter SI.PerUnit r13=0.01 "Resistance of the branch 1-3 (pu, transformer base)"
+  parameter SI.PerUnit r13=0.01 "Resistance of the branch 1-3 (transformer base)"
     annotation (Dialog(group="Transformer parameters"));
-  parameter SI.PerUnit r23=0.01 "Resistance of the branch 2-3 (pu, transformer base)"
+  parameter SI.PerUnit r23=0.01 "Resistance of the branch 2-3 (transformer base)"
     annotation (Dialog(group="Transformer parameters"));
-  parameter SI.PerUnit x12=0.1 "Reactance of the branch 1-2 (pu, transformer base)"
+  parameter SI.PerUnit x12=0.1 "Reactance of the branch 1-2 (transformer base)"
     annotation (Dialog(group="Transformer parameters"));
-  parameter SI.PerUnit x13=0.1 "Reactance of the branch 1-3 (pu, transformer base)"
+  parameter SI.PerUnit x13=0.1 "Reactance of the branch 1-3 (transformer base)"
     annotation (Dialog(group="Transformer parameters"));
-  parameter SI.PerUnit x23=0.1 "Reactance of the branch 2-3 (pu, transformer base)"
+  parameter SI.PerUnit x23=0.1 "Reactance of the branch 2-3 (transformer base)"
     annotation (Dialog(group="Transformer parameters"));
   parameter SI.PerUnit m=0.98 "Fixed tap ratio"
     annotation (Dialog(group="Transformer parameters"));

--- a/OpenIPSL/Electrical/Branches/PSAT/TwoWindingTransformer.mo
+++ b/OpenIPSL/Electrical/Branches/PSAT/TwoWindingTransformer.mo
@@ -17,9 +17,9 @@ model TwoWindingTransformer "Modeled as series reactances without iron losses"
     annotation (Dialog(group="Transformer parameters"));
   parameter SI.Voltage Vn(displayUnit="kV")=40e3 "Voltage rating"
     annotation (Dialog(group="Transformer parameters"));
-  parameter SI.PerUnit rT=0.01 "Resistance (pu, transformer base)"
+  parameter SI.PerUnit rT=0.01 "Resistance(transformer base)"
     annotation (Dialog(group="Transformer parameters"));
-  parameter SI.PerUnit xT=0.1 "Reactance (pu, transformer base)"
+  parameter SI.PerUnit xT=0.1 "Reactance(transformer base)"
     annotation (Dialog(group="Transformer parameters"));
   parameter Real m=1.0 "Optional fixed tap ratio"
     annotation (Dialog(group="Transformer parameters"));
@@ -39,8 +39,8 @@ model TwoWindingTransformer "Modeled as series reactances without iron losses"
 protected
   parameter SI.Impedance Zn = Vn^2/Sn "Transformer base impedance";
   parameter SI.Impedance Zb = V_b^2/S_b "System base impedance";
-  parameter SI.PerUnit r = rT * Zn/Zb "Resistance (pu, system base)";
-  parameter SI.PerUnit x = xT * Zn/Zb "Reactance (pu, system base)";
+  parameter SI.PerUnit r = rT * Zn/Zb "Resistance (system base)";
+  parameter SI.PerUnit x = xT * Zn/Zb "Reactance (system base)";
   parameter Boolean tc = m <> 1.0 "Internal parameter to switch on the icon arrow";
 equation
   r*p.ir - x*p.ii = 1/m^2*p.vr - 1/m*n.vr;

--- a/OpenIPSL/Electrical/Branches/PSAT/ULTC_VoltageControl.mo
+++ b/OpenIPSL/Electrical/Branches/PSAT/ULTC_VoltageControl.mo
@@ -15,14 +15,14 @@ model ULTC_VoltageControl
     annotation (Dialog(group="Transformer data"));
   parameter SI.Voltage Vn(displayUnit="kV")=400e3 "Voltage rating"
     annotation (Dialog(group="Transformer data"));
-  parameter SI.PerUnit rT=0.01 "Transformer resistance (pu, transformer base)"
+  parameter SI.PerUnit rT=0.01 "Transformer resistance(transformer base)"
     annotation (Dialog(group="Transformer data"));
-  parameter SI.PerUnit xT=0.2 "Transformer reactance (pu, transformer base)"
+  parameter SI.PerUnit xT=0.2 "Transformer reactance(transformer base)"
     annotation (Dialog(group="Transformer data"));
-  parameter SI.PerUnit v_ref=1.0 "Reference voltage (pu)"
+  parameter SI.PerUnit v_ref=1.0 "Reference voltage"
     annotation (Dialog(group="Voltage control"));
   parameter SI.PerUnit v_0=1.008959700699460
-    "Initial voltage magnitude of the controlled bus (pu)"
+    "Initial voltage magnitude of the controlled bus"
     annotation (Dialog(group="Voltage control"));
   parameter Real kT=4 "Nominal tap ratio (V1/V2)"
     annotation (Dialog(group="Voltage control"));
@@ -32,7 +32,7 @@ model ULTC_VoltageControl
     annotation (Dialog(group="Voltage control"));
   parameter SI.PerUnit m_min=0.9785 "Minimum tap ratio (pu/pu)"
     annotation (Dialog(group="Voltage control"));
-  parameter SI.PerUnit H=0.001 "Integral deviation (pu)"
+  parameter SI.PerUnit H=0.001 "Integral deviation"
     annotation (Dialog(group="Voltage control"));
   parameter SI.TimeAging K=0.10 "Inverse time constant"
     annotation (Dialog(group="Voltage control"));
@@ -41,16 +41,16 @@ model ULTC_VoltageControl
 //  parameter Real d=0.05 "Dead zone percentage"
 //    annotation (Dialog(group="Voltage control"));
   SI.PerUnit m "Tap ratio";
-  SI.PerUnit vk "Voltage at primary (pu)";
-  SI.PerUnit vm(start=v_0) "Voltage at secondary (pu)";
+  SI.PerUnit vk "Voltage at primary";
+  SI.PerUnit vm(start=v_0) "Voltage at secondary";
   SI.Angle anglevk "Angle at primary";
   SI.Angle anglevm "Angle at secondary ";
 protected
   parameter SI.Voltage V2=Vn/kT "Secondary voltage";
   parameter SI.Impedance Zn = Vn^2/Sn "Transformer base impedance";
   parameter SI.Impedance Zb = Vbus1^2/S_b "System base impedance";
-  parameter SI.PerUnit r = rT * Zn/Zb "Resistance (pu, system base)";
-  parameter SI.PerUnit x = xT * Zn/Zb "Reactance (pu, system base)";
+  parameter SI.PerUnit r = rT * Zn/Zb "Resistance(system base)";
+  parameter SI.PerUnit x = xT * Zn/Zb "Reactance(system base)";
   parameter SI.PerUnit vref=v_ref*(V2/Vbus2);
 initial equation
   m = m0;

--- a/OpenIPSL/Electrical/Branches/PSAT/ULTC_VoltageControl.mo
+++ b/OpenIPSL/Electrical/Branches/PSAT/ULTC_VoltageControl.mo
@@ -26,11 +26,11 @@ model ULTC_VoltageControl
     annotation (Dialog(group="Voltage control"));
   parameter Real kT=4 "Nominal tap ratio (V1/V2)"
     annotation (Dialog(group="Voltage control"));
-  parameter SI.PerUnit m0=0.98 "Initial tap ratio (pu/pu)"
+  parameter Real m0=0.98 "Initial tap ratio [pu/pu]"
     annotation (Dialog(group="Voltage control"));
-  parameter SI.PerUnit m_max=0.98 "Maximum tap ratio (pu/pu)"
+  parameter Real m_max=0.98 "Maximum tap ratio [pu/pu]"
     annotation (Dialog(group="Voltage control"));
-  parameter SI.PerUnit m_min=0.9785 "Minimum tap ratio (pu/pu)"
+  parameter Real m_min=0.9785 "Minimum tap ratio [pu/pu]"
     annotation (Dialog(group="Voltage control"));
   parameter SI.PerUnit H=0.001 "Integral deviation"
     annotation (Dialog(group="Voltage control"));

--- a/OpenIPSL/Electrical/Branches/PSSE/TwoWindingTransformer.mo
+++ b/OpenIPSL/Electrical/Branches/PSSE/TwoWindingTransformer.mo
@@ -13,27 +13,27 @@ model TwoWindingTransformer
           "Transformer impedance data"), choices(
       choice=1 "Z pu (winding kV system MVA)",
       choice=2 "Z pu (winding kV widing MVA)",
-      choice=3 "Load loss (W) & |Z| (pu)"));
-  parameter SI.PerUnit R "Specified R (pu)"
+      choice=3 "Load loss (W) & |Z| [pu]"));
+  parameter SI.PerUnit R "Specified R"
     annotation (Dialog(tab="Transformer impedance data"));
-  parameter SI.PerUnit X "Specified X (pu)"
+  parameter SI.PerUnit X "Specified X"
     annotation (Dialog(tab="Transformer impedance data"));
-  parameter SI.PerUnit G "Magnetizing G (pu)"
+  parameter SI.PerUnit G "Magnetizing G"
     annotation (Dialog(tab="Transformer impedance data"));
-  parameter SI.PerUnit B "Magnetizing B (pu)"
+  parameter SI.PerUnit B "Magnetizing B"
     annotation (Dialog(tab="Transformer impedance data"));
   parameter Integer CW=1 "Winding I/O code" annotation (Dialog(tab=
           "Transformer Nominal Ratings Data"), choices(
       choice=1 "Turns ratio (pu on bus base)",
       choice=2 "Winding voltage",
       choice=3 "Turns ratio (pu on nom wind)"));
-  parameter SI.PerUnit t1=1 "Winding 1 ratio (pu)"
+  parameter SI.PerUnit t1=1 "Winding 1 ratio"
     annotation (Dialog(tab="Transformer Nominal Ratings Data"));
   parameter SI.Voltage VNOM1(displayUnit="kV")=0 "Nominal voltage of winding 1"
     annotation (Dialog(tab="Transformer Nominal Ratings Data"));
   parameter SI.Voltage VB1(displayUnit="kV")=300e3 "Bus base voltage of winding 1"
     annotation (Dialog(tab="Transformer Nominal Ratings Data"));
-  parameter SI.PerUnit t2=1 "Secondary winding tap ratio (pu)"
+  parameter SI.PerUnit t2=1 "Secondary winding tap ratio"
     annotation (Dialog(tab="Transformer Nominal Ratings Data"));
   parameter SI.Voltage VNOM2(displayUnit="kV")=0 "Nominal Voltage of winding 2"
     annotation (Dialog(tab="Transformer Nominal Ratings Data"));

--- a/OpenIPSL/Electrical/Branches/PwLine.mo
+++ b/OpenIPSL/Electrical/Branches/PwLine.mo
@@ -9,20 +9,20 @@ model PwLine "Model for a transmission Line based on the pi-equivalent circuit"
             -10},{-80,10}}), iconTransformation(extent={{-100,-10},{-80,10}})));
   OpenIPSL.Interfaces.PwPin n annotation (Placement(transformation(extent={{80,
             -10},{100,10}}), iconTransformation(extent={{80,-10},{100,10}})));
-  parameter Modelica.SIunits.PerUnit R "Resistance (pu)"
+  parameter SI.PerUnit R "Resistance"
     annotation (Dialog(group="Line parameters"));
-  parameter Modelica.SIunits.PerUnit X "Reactance (pu)"
+  parameter SI.PerUnit X "Reactance"
     annotation (Dialog(group="Line parameters"));
-  parameter Modelica.SIunits.PerUnit G "Shunt half conductance (pu)"
+  parameter SI.PerUnit G "Shunt half conductance"
     annotation (Dialog(group="Line parameters"));
-  parameter Modelica.SIunits.PerUnit B "Shunt half susceptance (pu)"
+  parameter SI.PerUnit B "Shunt half susceptance"
     annotation (Dialog(group="Line parameters"));
   parameter SI.ApparentPower S_b(displayUnit="MVA")=SysData.S_b
     "System base power"
     annotation (Dialog(group="Line parameters", enable=false));
-  parameter Modelica.SIunits.Time t1=Modelica.Constants.inf
+  parameter SI.Time t1=Modelica.Constants.inf
     annotation (Dialog(group="Perturbation parameters"));
-  parameter Modelica.SIunits.Time t2=Modelica.Constants.inf
+  parameter SI.Time t2=Modelica.Constants.inf
     annotation (Dialog(group="Perturbation parameters"));
   parameter Integer opening=1 annotation (Dialog(group=
           "Perturbation parameters"), choices(

--- a/OpenIPSL/Electrical/Buses/Bus.mo
+++ b/OpenIPSL/Electrical/Buses/Bus.mo
@@ -16,7 +16,7 @@ model Bus "Bus model (2014/03/10)"
       iconTransformation(
         extent={{-10,-10},{10,10}})));
   SI.PerUnit V(start=v_0) "Bus voltage magnitude";
-  Modelica.SIunits.Conversions.NonSIunits.Angle_deg angle(start=angle_0)
+  SI.Conversions.NonSIunits.Angle_deg angle(start=angle_0)
     "Bus voltage angle";
 equation
   V = sqrt(p.vr^2 + p.vi^2);

--- a/OpenIPSL/Electrical/Buses/BusExt.mo
+++ b/OpenIPSL/Electrical/Buses/BusExt.mo
@@ -19,9 +19,9 @@ model BusExt
         extent={{-12,-100},{12,100}}),
       iconTransformation(
         extent={{-4,-60},{4,60}})));
-  SI.PerUnit v(start=v_0) "Bus voltage magnitude (pu)";
+  SI.PerUnit v(start=v_0) "Bus voltage magnitude";
   SI.Conversions.NonSIunits.Angle_deg angle(start=angle_0) "Bus voltage angle";
-  parameter SI.PerUnit v_0=1 "Voltage magnitude (pu)"
+  parameter SI.PerUnit v_0=1 "Voltage magnitude"
     annotation (Dialog(group="Power flow data"));
   parameter SI.Conversions.NonSIunits.Angle_deg angle_0=0 "Voltage angle"
     annotation (Dialog(group="Power flow data"));

--- a/OpenIPSL/Electrical/Controls/PSAT/TG/TGTypeIII.mo
+++ b/OpenIPSL/Electrical/Controls/PSAT/TG/TGTypeIII.mo
@@ -12,7 +12,7 @@ model TGTypeIII
   parameter SI.Time Tp "Pilot valve time constant";
   parameter SI.Time Tr "Dashpot time constant";
   parameter Real delta "Transient speed droop [pu/pu]";
-  parameter Real sigma "Permanent speed droop (pu/pu]";
+  parameter Real sigma "Permanent speed droop [pu/pu]";
   parameter SI.Time Tw "Water starting time";
   parameter Real a11 "Deriv. of flow rate vs. turbine head";
   parameter Real a13 "Deriv. of flow rate vs. gate position";

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/BaseClasses/BaseExciter.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/BaseClasses/BaseExciter.mo
@@ -16,7 +16,7 @@ partial model BaseExciter
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={0,-110})));
-  Modelica.Blocks.Interfaces.RealOutput EFD "Excitation Voltage (pu)"
+  Modelica.Blocks.Interfaces.RealOutput EFD "Excitation Voltage [pu]"
     annotation (Placement(transformation(extent={{200,-10},{220,10}}), iconTransformation(extent={{100,-10},{120,10}})));
   Modelica.Blocks.Interfaces.RealInput EFD0 annotation (Placement(
         transformation(

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/BaseClasses/RectifierCommutationVoltageDrop.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/BaseClasses/RectifierCommutationVoltageDrop.mo
@@ -1,6 +1,6 @@
 within OpenIPSL.Electrical.Controls.PSSE.ES.BaseClasses;
 model RectifierCommutationVoltageDrop
-  parameter Real K_C "Rectifier load factor (pu)";
+  parameter SI.PerUnit K_C "Rectifier load factor";
   Modelica.Blocks.Interfaces.RealInput V_EX annotation (Placement(
         transformation(extent={{-140,-20},{-100,20}}), iconTransformation(
           extent={{-120,-10},{-100,10}})));

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/BaseClasses/RotatingExciterBase.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/BaseClasses/RotatingExciterBase.mo
@@ -1,12 +1,12 @@
 within OpenIPSL.Electrical.Controls.PSSE.ES.BaseClasses;
 model RotatingExciterBase
-  parameter Real T_E "Exciter time constant (s)";
+  parameter SI.Time T_E "Exciter time constant";
   parameter Real K_E "Exciter field gain";
-  parameter Real E_1 "Exciter saturation point 1 (pu)";
-  parameter Real E_2 "Exciter saturation point 2 (pu)";
-  parameter Real S_EE_1 "Saturation at E_1";
-  parameter Real S_EE_2 "Saturation at E_2";
-  parameter Real Efd0;
+  parameter SI.PerUnit E_1 "Exciter saturation point 1";
+  parameter SI.PerUnit E_2 "Exciter saturation point 2";
+  parameter SI.PerUnit S_EE_1 "Saturation at E_1";
+  parameter SI.PerUnit S_EE_2 "Saturation at E_2";
+  parameter SI.PerUnit Efd0;
   Modelica.Blocks.Interfaces.RealInput I_C annotation (Placement(transformation(
           extent={{-120,-20},{-80,20}}), iconTransformation(extent={{-100,-10},
             {-80,10}})));

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/BaseClasses/RotatingExciterWithDemagnetization.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/BaseClasses/RotatingExciterWithDemagnetization.mo
@@ -6,7 +6,7 @@ model RotatingExciterWithDemagnetization
       k=1/T_E,
       initType=Modelica.Blocks.Types.Init.InitialOutput,
       y_start=Efd0));
-  parameter Real K_D "Exciter demagnetizing factor (pu)";
+  parameter SI.PerUnit K_D "Exciter demagnetizing factor";
   Modelica.Blocks.Interfaces.RealInput XADIFD annotation (Placement(
         transformation(
         extent={{-20,-20},{20,20}},

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/BaseClasses/RotatingExciterWithDemagnetizationVarLim.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/BaseClasses/RotatingExciterWithDemagnetizationVarLim.mo
@@ -3,7 +3,7 @@ model RotatingExciterWithDemagnetizationVarLim
   extends RotatingExciterWithDemagnetization(redeclare replaceable
       OpenIPSL.NonElectrical.Continuous.IntegratorLimVar sISO(K=1/T_E, y_start=
           Efd0), redeclare Modelica.Blocks.Math.Add3 Sum(k3=K_D));
-  parameter Real K_D "Exciter demagnetizing factor (pu)";
+  parameter SI.PerUnit K_D "Exciter demagnetizing factor";
   Modelica.Blocks.Interfaces.RealInput outMin annotation (Placement(
         transformation(extent={{-120,50},{-80,90}}), iconTransformation(extent=
             {{100,50},{80,70}})));

--- a/OpenIPSL/Electrical/Controls/PSSE/TG/HYGOV.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/TG/HYGOV.mo
@@ -44,10 +44,10 @@ model HYGOV "HYGOV - Hydro Turbine-Governor model"
     y_start=c0,
     initType=Modelica.Blocks.Types.Init.InitialOutput)
     annotation (Placement(transformation(extent={{-68,0},{-56,12}})));
-  Real G "Gate opening [pu]";
-  Real c "Desired gate opening [pu]";
-  Real Q "Turbine flow [pu]";
-  Real H "Turbine head [pu]";
+  SI.PerUnit G "Gate opening";
+  SI.PerUnit c "Desired gate opening";
+  SI.PerUnit Q "Turbine flow";
+  SI.PerUnit H "Turbine head";
   Modelica.Blocks.Math.Add add(k2=-1)
     annotation (Placement(transformation(extent={{-144,0},{-132,12}})));
   Modelica.Blocks.Math.Add add1

--- a/OpenIPSL/Electrical/Essentials/pfComponent.mo
+++ b/OpenIPSL/Electrical/Essentials/pfComponent.mo
@@ -54,7 +54,7 @@ partial model pfComponent
         __Dymola_compact=true,
         __Dymola_descriptionLabel=true), choices(checkBox=true));
   parameter SI.PerUnit v_0=1
-    "Initial voltage magnitude (pu)"
+    "Initial voltage magnitude)"
     annotation (Dialog(group="Power flow data", enable=enablev_0));
   parameter Boolean enablev_0 = false
     "Enable v_0 in parameter list"

--- a/OpenIPSL/Electrical/Essentials/pfComponent.mo
+++ b/OpenIPSL/Electrical/Essentials/pfComponent.mo
@@ -54,7 +54,7 @@ partial model pfComponent
         __Dymola_compact=true,
         __Dymola_descriptionLabel=true), choices(checkBox=true));
   parameter SI.PerUnit v_0=1
-    "Initial voltage magnitude)"
+    "Initial voltage magnitude"
     annotation (Dialog(group="Power flow data", enable=enablev_0));
   parameter Boolean enablev_0 = false
     "Enable v_0 in parameter list"

--- a/OpenIPSL/Electrical/Events/Breaker.mo
+++ b/OpenIPSL/Electrical/Events/Breaker.mo
@@ -2,13 +2,13 @@ within OpenIPSL.Electrical.Events;
 model Breaker "Circuit breaker with time or signal control"
   parameter Boolean enableTrigger=false "=true, if external trigger signal is used"
     annotation (Evaluate=true, choices(checkBox=true));
-  parameter Modelica.SIunits.Time t_o=Modelica.Constants.inf "Opening time"
+  parameter SI.Time t_o=Modelica.Constants.inf "Opening time"
     annotation (Dialog(enable=not enableTrigger));
   parameter Boolean rc_enabled=false "Enable reclosure" annotation (
     Evaluate=true,
     choices(checkBox=true),
     Dialog(enable=not enableTrigger));
-  parameter Modelica.SIunits.Time t_rc=Modelica.Constants.inf "Reclosing time"
+  parameter SI.Time t_rc=Modelica.Constants.inf "Reclosing time"
      annotation (Dialog(enable=not enableTrigger and rc_enabled));
   Interfaces.PwPin s "Sending pin"
     annotation (Placement(transformation(extent={{-110,-10},{-90,10}}),iconTransformation(extent={{-110,-10},{-90,10}})));

--- a/OpenIPSL/Electrical/Events/PwFault.mo
+++ b/OpenIPSL/Electrical/Events/PwFault.mo
@@ -3,10 +3,10 @@ model PwFault "Transitory short-circuit on a node. Shunt impedance connected onl
               Developed by AIA. 2014/12/16"
   OpenIPSL.Interfaces.PwPin p annotation (Placement(transformation(extent={{-80,
             -10},{-60,10}}), iconTransformation(extent={{-80,-10},{-60,10}})));
-  parameter Real R "Resistance (pu)";
-  parameter Real X "Reactance (pu)";
-  parameter Real t1 "Start time of the fault (s)";
-  parameter Real t2 "End time of the fault (s)";
+  parameter SI.PerUnit R "Resistance";
+  parameter SI.PerUnit X "Reactance";
+  parameter SI.Time t1 "Start time of the fault";
+  parameter SI.Time t2 "End time of the fault";
   import Modelica.Constants.eps;
 protected
   parameter Boolean ground=abs(R) < eps and abs(X) < eps;

--- a/OpenIPSL/Electrical/Events/PwFaultPQ.mo
+++ b/OpenIPSL/Electrical/Events/PwFaultPQ.mo
@@ -2,12 +2,12 @@ within OpenIPSL.Electrical.Events;
 model PwFaultPQ
   OpenIPSL.Interfaces.PwPin p annotation (Placement(transformation(extent={{-40,
             -10},{-20,10}}), iconTransformation(extent={{-80,-10},{-60,10}})));
-  parameter Real R "Resistance (pu)";
-  parameter Real X "Reactance (pu)";
-  parameter Real t1 "Start time of the fault (s)";
-  parameter Real t2 "End time of the fault (s)";
-  Real P "Active power supplied to the fault (pu)";
-  Real Q "Reactive power supplied to the fault (pu)";
+  parameter SI.PerUnit R "Resistance";
+  parameter SI.PerUnit X "Reactance";
+  parameter SI.Time t1 "Start time of the fault";
+  parameter SI.Time t2 "End time of the fault";
+  SI.PerUnit P "Active power supplied to the fault";
+  SI.PerUnit Q "Reactive power supplied to the fault";
 equation
   p.ir = if time < t1 then 0 else if time < t2 then 1/X*(p.vi - R*p.ii) else 0;
   p.ii = if time < t1 then 0 else if time < t2 then (R*p.vi - X*p.vr)/(X*X + R*

--- a/OpenIPSL/Electrical/FACTS/PSAT/STATCOM.mo
+++ b/OpenIPSL/Electrical/FACTS/PSAT/STATCOM.mo
@@ -21,7 +21,7 @@ model STATCOM "Static Synchronous Compensator model with equation"
     annotation (Dialog(group="Power flow data"));
   //parameter Real v_ref=1.002791151905167 "Reference voltage of the STATCOM regulator (pu)" annotation(Dialog(group="Power flow data"));
   parameter Real Kr=50 "Regulator gain (p.u./p.u.)";
-  parameter SI.PerUnit Tr=0.01 "Regulator time constant (s)";
+  parameter SI.Time Tr=0.01 "Regulator time constant";
   parameter SI.PerUnit i_Max=0.7 "Maximum current (pu)";
   parameter SI.PerUnit i_Min=-0.1 "Minimum current (pu)";
   parameter SI.PerUnit v_POD=0 "Power oscillation damper signal";

--- a/OpenIPSL/Electrical/FACTS/PSAT/STATCOM.mo
+++ b/OpenIPSL/Electrical/FACTS/PSAT/STATCOM.mo
@@ -3,42 +3,41 @@ model STATCOM "Static Synchronous Compensator model with equation"
   OpenIPSL.Interfaces.PwPin p(vr(start=vr0), vi(start=vi0)) annotation (
       Placement(transformation(extent={{100,-10},{120,10}}), iconTransformation(
           extent={{100,-10},{120,10}})));
-  constant Real pi=Modelica.Constants.pi;
-  parameter Real Sb=100 "System base power (MVA)"
+  parameter SI.ApparentPower(displayUnit="MVA") Sb=100 "System base power"
     annotation (Dialog(group="Power flow data"));
-  parameter Real Vbus=400000 "Bus nominal voltage (V)"
+  parameter SI.Voltage Vbus=400000 "Bus nominal voltage"
     annotation (Dialog(group="Power flow data"));
-  parameter Real Sn=100 "Power rating (MVA)"
+  parameter SI.ApparentPower Sn=100 "Power rating (MVA)"
     annotation (Dialog(group="Power flow data"));
-  parameter Real Vn=400000 "Voltage rating (V)"
+  parameter SI.Voltage Vn=400000 "Voltage rating (V)"
     annotation (Dialog(group="Power flow data"));
-  parameter Real fn=50 "Frequency rating (Hz)"
+  parameter SI.Frequency fn=50 "Frequency rating (Hz)"
     annotation (Dialog(group="Power flow data"));
-  parameter Real V_0=1 "Voltage magnitude (pu)"
+  parameter SI.PerUnit V_0=1 "Voltage magnitude (pu)"
     annotation (Dialog(group="Power flow data"));
-  parameter Real angle_0=-0.000213067852480 "Voltage angle (deg.)"
+  parameter SI.Conversions.NonSIunits.Angle_deg angle_0=-0.000213067852480 "Voltage angle (deg.)"
     annotation (Dialog(group="Power flow data"));
-  parameter Real Qg=0.139557595258338 "Reactive power injection(p.u.)"
+  parameter SI.PerUnit Qg=0.139557595258338 "Reactive power injection(p.u.)"
     annotation (Dialog(group="Power flow data"));
   //parameter Real v_ref=1.002791151905167 "Reference voltage of the STATCOM regulator (pu)" annotation(Dialog(group="Power flow data"));
   parameter Real Kr=50 "Regulator gain (p.u./p.u.)";
-  parameter Real Tr=0.01 "Regulator time constant (s)";
-  parameter Real i_Max=0.7 "Maximum current (pu)";
-  parameter Real i_Min=-0.1 "Minimum current (pu)";
-  parameter Real v_POD=0 "Power oscillation damper signal";
-  Real i_SH "STATCOM current (pu)";
-  Real v(start=V_0) "Bus voltage magnitude (pu)";
-  Real Q(start=Qg) "Injected reactive power (pu)";
+  parameter SI.PerUnit Tr=0.01 "Regulator time constant (s)";
+  parameter SI.PerUnit i_Max=0.7 "Maximum current (pu)";
+  parameter SI.PerUnit i_Min=-0.1 "Minimum current (pu)";
+  parameter SI.PerUnit v_POD=0 "Power oscillation damper signal";
+  SI.PerUnit i_SH "STATCOM current (pu)";
+  SI.PerUnit v(start=V_0) "Bus voltage magnitude (pu)";
+  SI.PerUnit Q(start=Qg) "Injected reactive power (pu)";
 protected
   parameter Real Iold=Sn/Vn;
   parameter Real Inew=Sb/Vbus;
-  parameter Real i_max=i_Max*Iold/Inew;
-  parameter Real i_min=i_Min*Iold/Inew;
-  parameter Real vr0=V_0*cos(angle_0/180*pi) "Initialitation";
-  parameter Real vi0=V_0*sin(angle_0/180*pi) "Initialitation";
-  parameter Real uo=v_ref + v_POD - V_0 "Initialization";
-  parameter Real io=Qg/V_0 "Initialization";
-  parameter Real v_ref=io/Kr + V_0 - v_POD "Initialization";
+  parameter SI.PerUnit i_max=i_Max*Iold/Inew;
+  parameter SI.PerUnit i_min=i_Min*Iold/Inew;
+  parameter SI.PerUnit vr0=V_0*cos(angle_0/180*pi) "Initialitation";
+  parameter SI.PerUnit vi0=V_0*sin(angle_0/180*pi) "Initialitation";
+  parameter SI.PerUnit uo=v_ref + v_POD - V_0 "Initialization";
+  parameter SI.PerUnit io=Qg/V_0 "Initialization";
+  parameter SI.PerUnit v_ref=io/Kr + V_0 - v_POD "Initialization";
   //parameter Real vmin=v_ref + v_POD - i_max/Kr;
   //parameter Real vmax=v_ref + v_POD - i_min/Kr;
   //parameter Real umax=i_max/Kr;

--- a/OpenIPSL/Electrical/FACTS/PSAT/STATCOM.mo
+++ b/OpenIPSL/Electrical/FACTS/PSAT/STATCOM.mo
@@ -3,41 +3,42 @@ model STATCOM "Static Synchronous Compensator model with equation"
   OpenIPSL.Interfaces.PwPin p(vr(start=vr0), vi(start=vi0)) annotation (
       Placement(transformation(extent={{100,-10},{120,10}}), iconTransformation(
           extent={{100,-10},{120,10}})));
-  parameter SI.ApparentPower(displayUnit="MVA") Sb=100 "System base power"
+  constant Real pi=Modelica.Constants.pi;
+  parameter Real Sb=100 "System base power (MVA)"
     annotation (Dialog(group="Power flow data"));
-  parameter SI.Voltage Vbus=400000 "Bus nominal voltage"
+  parameter Real Vbus=400000 "Bus nominal voltage (V)"
     annotation (Dialog(group="Power flow data"));
-  parameter SI.ApparentPower Sn=100 "Power rating (MVA)"
+  parameter Real Sn=100 "Power rating (MVA)"
     annotation (Dialog(group="Power flow data"));
-  parameter SI.Voltage Vn=400000 "Voltage rating (V)"
+  parameter Real Vn=400000 "Voltage rating (V)"
     annotation (Dialog(group="Power flow data"));
-  parameter SI.Frequency fn=50 "Frequency rating (Hz)"
+  parameter Real fn=50 "Frequency rating (Hz)"
     annotation (Dialog(group="Power flow data"));
-  parameter SI.PerUnit V_0=1 "Voltage magnitude (pu)"
+  parameter Real V_0=1 "Voltage magnitude (pu)"
     annotation (Dialog(group="Power flow data"));
-  parameter SI.Conversions.NonSIunits.Angle_deg angle_0=-0.000213067852480 "Voltage angle (deg.)"
+  parameter Real angle_0=-0.000213067852480 "Voltage angle (deg.)"
     annotation (Dialog(group="Power flow data"));
-  parameter SI.PerUnit Qg=0.139557595258338 "Reactive power injection(p.u.)"
+  parameter Real Qg=0.139557595258338 "Reactive power injection(p.u.)"
     annotation (Dialog(group="Power flow data"));
   //parameter Real v_ref=1.002791151905167 "Reference voltage of the STATCOM regulator (pu)" annotation(Dialog(group="Power flow data"));
   parameter Real Kr=50 "Regulator gain (p.u./p.u.)";
-  parameter SI.Time Tr=0.01 "Regulator time constant";
-  parameter SI.PerUnit i_Max=0.7 "Maximum current (pu)";
-  parameter SI.PerUnit i_Min=-0.1 "Minimum current (pu)";
-  parameter SI.PerUnit v_POD=0 "Power oscillation damper signal";
-  SI.PerUnit i_SH "STATCOM current (pu)";
-  SI.PerUnit v(start=V_0) "Bus voltage magnitude (pu)";
-  SI.PerUnit Q(start=Qg) "Injected reactive power (pu)";
+  parameter Real Tr=0.01 "Regulator time constant (s)";
+  parameter Real i_Max=0.7 "Maximum current (pu)";
+  parameter Real i_Min=-0.1 "Minimum current (pu)";
+  parameter Real v_POD=0 "Power oscillation damper signal";
+  Real i_SH "STATCOM current (pu)";
+  Real v(start=V_0) "Bus voltage magnitude (pu)";
+  Real Q(start=Qg) "Injected reactive power (pu)";
 protected
   parameter Real Iold=Sn/Vn;
   parameter Real Inew=Sb/Vbus;
-  parameter SI.PerUnit i_max=i_Max*Iold/Inew;
-  parameter SI.PerUnit i_min=i_Min*Iold/Inew;
-  parameter SI.PerUnit vr0=V_0*cos(angle_0/180*pi) "Initialitation";
-  parameter SI.PerUnit vi0=V_0*sin(angle_0/180*pi) "Initialitation";
-  parameter SI.PerUnit uo=v_ref + v_POD - V_0 "Initialization";
-  parameter SI.PerUnit io=Qg/V_0 "Initialization";
-  parameter SI.PerUnit v_ref=io/Kr + V_0 - v_POD "Initialization";
+  parameter Real i_max=i_Max*Iold/Inew;
+  parameter Real i_min=i_Min*Iold/Inew;
+  parameter Real vr0=V_0*cos(angle_0/180*pi) "Initialitation";
+  parameter Real vi0=V_0*sin(angle_0/180*pi) "Initialitation";
+  parameter Real uo=v_ref + v_POD - V_0 "Initialization";
+  parameter Real io=Qg/V_0 "Initialization";
+  parameter Real v_ref=io/Kr + V_0 - v_POD "Initialization";
   //parameter Real vmin=v_ref + v_POD - i_max/Kr;
   //parameter Real vmax=v_ref + v_POD - i_min/Kr;
   //parameter Real umax=i_max/Kr;

--- a/OpenIPSL/Electrical/Loads/NoiseInjections/SineNoiseInjection.mo
+++ b/OpenIPSL/Electrical/Loads/NoiseInjections/SineNoiseInjection.mo
@@ -2,10 +2,10 @@ within OpenIPSL.Electrical.Loads.NoiseInjections;
 model SineNoiseInjection
   extends BaseClass;
   parameter Real amplitude=1 "Amplitude of sine wave";
-  parameter Modelica.SIunits.Frequency freqHz(start=1) "Frequency of sine wave";
-  parameter Modelica.SIunits.Angle phase=0 "Phase of sine wave";
+  parameter SI.Frequency freqHz(start=1) "Frequency of sine wave";
+  parameter SI.Angle phase=0 "Phase of sine wave";
   parameter Real offset=0 "Offset of output signal";
-  parameter Modelica.SIunits.Time startTime=0
+  parameter SI.Time startTime=0
     "Output = offset for time < startTime";
 
   Modelica.Blocks.Sources.Sine sine(

--- a/OpenIPSL/Electrical/Loads/PSAT/BaseClasses/baseLoad.mo
+++ b/OpenIPSL/Electrical/Loads/PSAT/BaseClasses/baseLoad.mo
@@ -10,11 +10,11 @@ partial model baseLoad
     final enableQ_0=true,
     final enableP_0=true);
   parameter SI.ApparentPower Sn(displayUnit="MVA")=S_b "Power rating";
-  SI.PerUnit v(start=v_0) "Voltage magnitude (pu)";
-  SI.Angle Angle_V(start=Modelica.SIunits.Conversions.from_deg(
+  SI.PerUnit v(start=v_0) "Voltage magnitude";
+  SI.Angle Angle_V(start=SI.Conversions.from_deg(
         angle_0)) "Voltage angle";
-  SI.PerUnit P(start=P_0/S_b) "Active power (pu)";
-  SI.PerUnit Q(start=Q_0/S_b) "Reactive power (pu)";
+  SI.PerUnit P(start=P_0/S_b) "Active power";
+  SI.PerUnit Q(start=Q_0/S_b) "Reactive power";
   Interfaces.PwPin p(vr(start=v_0*cos(angle_0rad)),vi(start=v_0*sin(angle_0rad)))
     annotation (Placement(transformation(extent={{-10,90},{10,110}})));
 protected

--- a/OpenIPSL/Electrical/Loads/PSAT/ExponentialRecovery.mo
+++ b/OpenIPSL/Electrical/Loads/PSAT/ExponentialRecovery.mo
@@ -1,16 +1,16 @@
 within OpenIPSL.Electrical.Loads.PSAT;
 model ExponentialRecovery "Exload - Exponential Recovery Load"
   extends BaseClasses.baseLoad;
-  parameter Real Tp=1 "Active power time constant (s)";
-  parameter Real Tq=1 "Reactive power time constant (s)";
+  parameter SI.Time Tp=1 "Active power time constant";
+  parameter SI.Time Tq=1 "Reactive power time constant";
   parameter Real alpha_s=2 "Static active power exponent";
   parameter Real alpha_t=1.5 "Dynamic active power exponent";
   parameter Real beta_s=2 "Static reactive power exponent";
   parameter Real beta_t=1.5 "Dynamic reactive power exponent";
-  Real ps "Static real power absorption (pu)";
-  Real pt "Transient real power absorption (pu)";
-  Real qs "Static imaginary power absorption (pu)";
-  Real qt "Transient imaginary power absorption (pu)";
+  SI.PerUnit ps "Static real power absorption";
+  SI.PerUnit pt "Transient real power absorption";
+  SI.PerUnit qs "Static imaginary power absorption";
+  SI.PerUnit qt "Transient imaginary power absorption";
 protected
   Real xp(start=0);
   Real xq(start=0);

--- a/OpenIPSL/Electrical/Loads/PSAT/FrequencyDependent.mo
+++ b/OpenIPSL/Electrical/Loads/PSAT/FrequencyDependent.mo
@@ -5,8 +5,8 @@ model FrequencyDependent "Fl - Frequency Dependent Load"
   parameter Real alpha_q=0 "Reactive power voltage coefficient";
   parameter Real beta_p=1.3 "Active power frequency coefficient";
   parameter Real beta_q=1.3 "Reactive power frequency coefficient";
-  parameter Real Tf=0.1 "Filter time constant (s)";
-  Real deltaw "Frequency deviation (pu)";
+  parameter SI.Time Tf=0.1 "Filter time constant";
+  SI.PerUnit deltaw "Frequency deviation";
 protected
   Real a "Auxiliary variable, voltage division";
   Real x(start=0) "auxiliary variable";

--- a/OpenIPSL/Electrical/Loads/PSAT/Mixed.mo
+++ b/OpenIPSL/Electrical/Loads/PSAT/Mixed.mo
@@ -1,15 +1,15 @@
 within OpenIPSL.Electrical.Loads.PSAT;
 model Mixed "Mixload - Mixed Load"
   extends BaseClasses.baseLoad;
-  parameter Real Kpf=0 "Frequency coefficient for the active power (pu)";
+  parameter SI.PerUnit Kpf=0 "Frequency coefficient for the active power";
   parameter Real alpha=0 "Voltage exponent for the active power";
-  parameter Real Tpv=0.12 "Time constant of dV/dt for the active power (s)";
-  parameter Real Kqf=0 "Frequency coefficient for the reactive power (pu)";
+  parameter SI.Time Tpv=0.12 "Time constant of dV/dt for the active power";
+  parameter SI.PerUnit Kqf=0 "Frequency coefficient for the reactive power";
   parameter Real beta=0 "Voltage exponent for the reactive power";
-  parameter Real Tqv=0.075 "Time constant of dV/dt for the reactive power (s)";
-  parameter Real Tfv=0.005 "Time constant of voltage magnitude filter (s)";
-  parameter Real Tft=0.007 "Time constant of voltage angle filter (s)";
-  Real deltaw "Frequency deviation (pu)";
+  parameter SI.Time Tqv=0.075 "Time constant of dV/dt for the reactive power";
+  parameter SI.Time Tfv=0.005 "Time constant of voltage magnitude filter";
+  parameter SI.Time Tft=0.007 "Time constant of voltage angle filter";
+  SI.PerUnit deltaw "Frequency deviation";
 protected
   Real a "Auxiliary variable, voltage division";
   Real b "Auxiliary variable, derivation";

--- a/OpenIPSL/Electrical/Loads/PSAT/PQvar.mo
+++ b/OpenIPSL/Electrical/Loads/PSAT/PQvar.mo
@@ -24,9 +24,9 @@ model PQvar "Equations come from the mathematical separation in between reals an
   parameter SI.ReactivePower dQ2(displayUnit="Mvar")=0
     "Second reactive load variation"
     annotation (Dialog(group="Variation 2"));
-  parameter SI.PerUnit Vmax=1.2 "maximum voltage (pu)"
+  parameter SI.PerUnit Vmax=1.2 "maximum voltage"
     annotation (Evaluate=true, Dialog(tab="To Be Implemented"));
-  parameter SI.PerUnit Vmin=0.8 "minimum voltage (pu)"
+  parameter SI.PerUnit Vmin=0.8 "minimum voltage"
     annotation (Evaluate=true, Dialog(tab="To Be Implemented"));
   parameter Boolean forcePQ=true
     "force 'constant' PQ-load, false may cause simulation problems"

--- a/OpenIPSL/Electrical/Loads/PSAT/ZIP.mo
+++ b/OpenIPSL/Electrical/Loads/PSAT/ZIP.mo
@@ -1,12 +1,12 @@
 within OpenIPSL.Electrical.Loads.PSAT;
 model ZIP "ZIP Load"
   extends BaseClasses.baseLoad;
-  parameter Real Pz=0.33 "Conductance (pu)";
-  parameter Real Pi=0.33 "Active current (pu)";
-  parameter Real Pp=1 - Pz - Pi "Active power (pu)";
-  parameter Real Qz=0.33 "Susceptance (pu)";
-  parameter Real Qi=0.33 "Reactive current (pu)";
-  parameter Real Qp=1 - Qz - Qi "Reactive power (pu)";
+  parameter SI.PerUnit Pz=0.33 "Conductance";
+  parameter SI.PerUnit Pi=0.33 "Active current";
+  parameter SI.PerUnit Pp=1 - Pz - Pi "Active power";
+  parameter SI.PerUnit Qz=0.33 "Susceptance";
+  parameter SI.PerUnit Qi=0.33 "Reactive current";
+  parameter SI.PerUnit Qp=1 - Qz - Qi "Reactive power";
 protected
   Real a "Auxiliary variable, voltage division";
 equation

--- a/OpenIPSL/Electrical/Loads/PSAT/ZIP_ExtInput.mo
+++ b/OpenIPSL/Electrical/Loads/PSAT/ZIP_ExtInput.mo
@@ -1,12 +1,12 @@
 within OpenIPSL.Electrical.Loads.PSAT;
 model ZIP_ExtInput "PSAT ZIP load with additional input"
   extends OpenIPSL.Electrical.Loads.PSAT.BaseClasses.baseLoad;
-  parameter Real Pz=0.33 "Conductance (pu)";
-  parameter Real Pi=0.33 "Active current (pu)";
-  parameter Real Pp=1 - Pz - Pi "Active power (pu)";
-  parameter Real Qz=0.33 "Susceptance (pu)";
-  parameter Real Qi=0.33 "Reactive current (pu)";
-  parameter Real Qp=1 - Qz - Qi "Reactive power (pu)";
+  parameter SI.PerUnit Pz=0.33 "Conductance";
+  parameter SI.PerUnit Pi=0.33 "Active current";
+  parameter SI.PerUnit Pp=1 - Pz - Pi "Active power";
+  parameter SI.PerUnit Qz=0.33 "Susceptance";
+  parameter SI.PerUnit Qi=0.33 "Reactive current";
+  parameter SI.PerUnit Qp=1 - Qz - Qi "Reactive power";
 protected
   Real a "Auxiliary variable, voltage division";
 public

--- a/OpenIPSL/Electrical/Loads/PSAT/ZIP_Jimma.mo
+++ b/OpenIPSL/Electrical/Loads/PSAT/ZIP_Jimma.mo
@@ -1,14 +1,14 @@
 within OpenIPSL.Electrical.Loads.PSAT;
 model ZIP_Jimma "Jimma - Jimma's Load"
   extends BaseClasses.baseLoad;
-  parameter Real Tf=0.01 "Time constant of the high-pass filter (s)";
-  parameter Real Pz=0.33 "Conductance";
-  parameter Real Pi=0.33 "Active current";
-  parameter Real Pp=1 - Pz - Pi "Active power";
-  parameter Real Qz=0.33 "Susceptance";
-  parameter Real Qi=0.33 "Reactive current";
-  parameter Real Qp=1 - Qz - Qi "Reactive power";
-  parameter Real Kv=100 "coefficient of the voltage time derivative (1/s)";
+  parameter SI.Time Tf=0.01 "Time constant of the high-pass filter";
+  parameter SI.PerUnit Pz=0.33 "Conductance";
+  parameter SI.PerUnit Pi=0.33 "Active current";
+  parameter SI.PerUnit Pp=1 - Pz - Pi "Active power";
+  parameter SI.PerUnit Qz=0.33 "Susceptance";
+  parameter SI.PerUnit Qi=0.33 "Reactive current";
+  parameter SI.PerUnit Qp=1 - Qz - Qi "Reactive power";
+  parameter SI.TimeAging Kv=100 "coefficient of the voltage time derivative";
 protected
   Real a "Auxiliary variable, voltage division";
   Real b "Auxiliary variable, derivation";

--- a/OpenIPSL/Electrical/Loads/PSSE/BaseClasses/baseLoad.mo
+++ b/OpenIPSL/Electrical/Loads/PSSE/BaseClasses/baseLoad.mo
@@ -28,10 +28,10 @@ partial model baseLoad
     ir(start=ir0),
     ii(start=ii0))
     annotation (Placement(transformation(extent={{-10,90},{10,110}})));
-  Modelica.SIunits.Angle angle(start=angle_0rad) "Bus voltage angle";
-  SI.PerUnit v(start=v_0) "Bus voltage magnitude (pu)";
-  SI.PerUnit P "Active power consumption (pu)";
-  SI.PerUnit Q "Reactive power consumption (pu)";
+  SI.Angle angle(start=angle_0rad) "Bus voltage angle";
+  SI.PerUnit v(start=v_0) "Bus voltage magnitude";
+  SI.PerUnit P "Active power consumption";
+  SI.PerUnit Q "Reactive power consumption";
 protected
   parameter SI.PerUnit p0=(S_i.re*v_0 + S_y.re*v_0^2 + S_p.re)/S_b "pu";
   parameter SI.PerUnit q0=(S_i.im*v_0 + S_y.im*v_0^2 + S_p.im)/S_b "pu";

--- a/OpenIPSL/Electrical/Loads/PSSE/BaseClasses/baseLoad.mo
+++ b/OpenIPSL/Electrical/Loads/PSSE/BaseClasses/baseLoad.mo
@@ -33,18 +33,18 @@ partial model baseLoad
   SI.PerUnit P "Active power consumption";
   SI.PerUnit Q "Reactive power consumption";
 protected
-  parameter SI.PerUnit p0=(S_i.re*v_0 + S_y.re*v_0^2 + S_p.re)/S_b "pu";
-  parameter SI.PerUnit q0=(S_i.im*v_0 + S_y.im*v_0^2 + S_p.im)/S_b "pu";
-  parameter SI.PerUnit vr0=v_0*cos(angle_0rad) "Initialitation";
-  parameter SI.PerUnit vi0=v_0*sin(angle_0rad) "Initialitation";
-  parameter SI.PerUnit ir0=(p0*vr0 + q0*vi0)/(vr0^2 + vi0^2) "Initialitation";
-  parameter SI.PerUnit ii0=(p0*vi0 - q0*vr0)/(vr0^2 + vi0^2) "Initialitation";
+  parameter SI.PerUnit p0=(S_i.re*v_0 + S_y.re*v_0^2 + S_p.re)/S_b "Initial active power";
+  parameter SI.PerUnit q0=(S_i.im*v_0 + S_y.im*v_0^2 + S_p.im)/S_b "Initial reactive power";
+  parameter SI.PerUnit vr0=v_0*cos(angle_0rad) "Initial real voltage";
+  parameter SI.PerUnit vi0=v_0*sin(angle_0rad) "Initial imaginary voltage";
+  parameter SI.PerUnit ir0=(p0*vr0 + q0*vi0)/(vr0^2 + vi0^2) "Initial real current";
+  parameter SI.PerUnit ii0=(p0*vi0 - q0*vr0)/(vr0^2 + vi0^2) "Initial imaginary current";
   parameter Complex S_P=Complex((1 - a.re - b.re)*S_p.re, (1 - a.im - b.im)*S_p.im)
-      /S_b "pu";
+      /S_b "[pu]";
   parameter Complex S_I=(S_i + Complex(a.re*S_p.re/v_0, a.im*S_p.im/v_0))/S_b
-    "pu";
+    "[pu]";
   parameter Complex S_Y=(S_y + Complex(b.re*S_p.re/v_0^2, b.im*S_p.im/v_0^2))/
-      S_b "pu";
+      S_b "[pu]";
   //Constant current load vary function when voltage is below 0.5
   parameter Real a2=1.502;
   parameter Real b2=1.769;

--- a/OpenIPSL/Electrical/Loads/PSSE/Load_ExtInput.mo
+++ b/OpenIPSL/Electrical/Loads/PSSE/Load_ExtInput.mo
@@ -1,9 +1,9 @@
 within OpenIPSL.Electrical.Loads.PSSE;
 model Load_ExtInput "PSS/E Load with variation"
   extends OpenIPSL.Electrical.Loads.PSSE.BaseClasses.baseLoad;
-  parameter Real d_P "Active Load Variation (pu)";
-  parameter Modelica.SIunits.Time t1 "Time of Load Variation";
-  parameter Modelica.SIunits.Time d_t "Time duration of load variation";
+  parameter SI.PerUnit d_P "Active Load Variation";
+  parameter SI.Time t1 "Time of Load Variation";
+  parameter SI.Time d_t "Time duration of load variation";
 protected
   parameter Real PF=if q0 == 0 then 1 else p0/q0;
   parameter Real d_Q=(p0 + d_P)/PF - q0;

--- a/OpenIPSL/Electrical/Loads/PSSE/Load_switch.mo
+++ b/OpenIPSL/Electrical/Loads/PSSE/Load_switch.mo
@@ -1,8 +1,8 @@
 within OpenIPSL.Electrical.Loads.PSSE;
 model Load_switch "PSS/E Load"
   extends OpenIPSL.Electrical.Loads.PSSE.BaseClasses.baseLoad;
-  parameter Modelica.SIunits.Time t1 "Time of switching on";
-  parameter Modelica.SIunits.Time t2 "Time of switching off";
+  parameter SI.Time t1 "Time of switching on";
+  parameter SI.Time t2 "Time of switching off";
 equation
   if time >= t1 and time < t2 then
     kI*S_I.re*v + S_Y.re*v^2 + kP*S_P.re = p.vr*p.ir + p.vi*p.ii;

--- a/OpenIPSL/Electrical/Loads/PSSE/Load_variation.mo
+++ b/OpenIPSL/Electrical/Loads/PSSE/Load_variation.mo
@@ -1,9 +1,9 @@
 within OpenIPSL.Electrical.Loads.PSSE;
 model Load_variation "PSS/E Load with variation"
   extends BaseClasses.baseLoad;
-  parameter Real d_P "Active Load Variation (pu)";
-  parameter Modelica.SIunits.Time t1 "Time of Load Variation";
-  parameter Modelica.SIunits.Time d_t "Time duration of load variation";
+  parameter SI.PerUnit d_P "Active Load Variation";
+  parameter SI.Time t1 "Time of Load Variation";
+  parameter SI.Time d_t "Time duration of load variation";
 protected
   parameter Real PF=if q0 == 0 then 1 else p0/q0;
   parameter Real d_Q=(p0 + d_P)/PF - q0;

--- a/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
@@ -35,7 +35,7 @@ partial model baseMachine
     start=delta0,
     quantity="Angle",
     unit="rad",
-    displayUnit="rad") "Rotor angle (rad)" annotation (Placement(transformation(
+    displayUnit="rad") "Rotor angle" annotation (Placement(transformation(
         origin={110,60},
         extent={{-10,-10},{10,10}})));
   Modelica.Blocks.Interfaces.RealOutput w(start=1) "Rotor speed (pu)"

--- a/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
@@ -19,7 +19,7 @@ partial model baseMachine
     annotation (Dialog(group="Machine parameters"));
   parameter SI.PerUnit x1d "d-axis transient reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.Time M "Mechanical starting time, 2H (MWs/MVA)"
+  parameter SI.Time M "Mechanical starting time, 2H [Ws/VA]"
     annotation (Dialog(group="Machine parameters"));
   parameter Real D "Damping coefficient"
     annotation (Dialog(group="Machine parameters"));

--- a/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/BaseClasses/baseMachine.mo
@@ -15,9 +15,9 @@ partial model baseMachine
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Voltage Vn(displayUnit="kV") "Voltage rating"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit ra "Armature resistance (pu)"
+  parameter SI.PerUnit ra "Armature resistance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit x1d "d-axis transient reactance (pu)"
+  parameter SI.PerUnit x1d "d-axis transient reactance"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time M "Mechanical starting time, 2H (MWs/MVA)"
     annotation (Dialog(group="Machine parameters"));
@@ -38,46 +38,46 @@ partial model baseMachine
     displayUnit="rad") "Rotor angle" annotation (Placement(transformation(
         origin={110,60},
         extent={{-10,-10},{10,10}})));
-  Modelica.Blocks.Interfaces.RealOutput w(start=1) "Rotor speed (pu)"
+  Modelica.Blocks.Interfaces.RealOutput w(start=1) "Rotor speed [pu]"
     annotation (Placement(transformation(
         origin={110,90},
         extent={{-10,-10},{10,10}})));
   Modelica.Blocks.Interfaces.RealOutput v(start=v_0)
-    "Generator terminal voltage (pu)" annotation (Placement(transformation(
+    "Generator terminal voltage [pu]" annotation (Placement(transformation(
         origin={110,30},
         extent={{-10,-10},{10,10}})));
-  Modelica.Blocks.Interfaces.RealOutput P(start=p0) "Active power (pu)"
+  Modelica.Blocks.Interfaces.RealOutput P(start=p0) "Active power [pu]"
     annotation (Placement(transformation(
         origin={110,-30},
         extent={{-10,-10},{10,10}})));
-  Modelica.Blocks.Interfaces.RealOutput Q(start=q0) "Reactive power (pu)"
+  Modelica.Blocks.Interfaces.RealOutput Q(start=q0) "Reactive power [pu]"
     annotation (Placement(transformation(
         origin={110,-70},
         extent={{-10,-10},{10,10}})));
-  Modelica.Blocks.Interfaces.RealInput vf "Field voltage (pu)" annotation (
+  Modelica.Blocks.Interfaces.RealInput vf "Field voltage [pu]" annotation (
       Placement(transformation(
         origin={-120,50},
         extent={{-20,-20},{20,20}})));
-  Modelica.Blocks.Interfaces.RealOutput vf0 "Initial field voltage (pu)"
+  Modelica.Blocks.Interfaces.RealOutput vf0 "Initial field voltage [pu]"
     annotation (Placement(transformation(
         origin={-80,110},
         extent={{-10,-10},{10,10}},
         rotation=90)));
   Modelica.Blocks.Interfaces.RealOutput pm0(start=pm00)
-    "Initial mechanical power (pu)" annotation (Placement(transformation(
+    "Initial mechanical power [pu]" annotation (Placement(transformation(
         origin={-80,-110},
         extent={{-10,-10},{10,10}},
         rotation=270)));
-  Modelica.Blocks.Interfaces.RealInput pm(start=pm00) "Mechanical power (pu)"
+  Modelica.Blocks.Interfaces.RealInput pm(start=pm00) "Mechanical power [pu]"
     annotation (Placement(transformation(
         origin={-120,-50},
         extent={{-20,-20},{20,20}})));
   SI.Angle anglev(start=SI.Conversions.from_deg(angle_0))
     " Bus voltage angle (rad)";
-  Real vd(start=vd0) "d-axis voltage (pu)";
-  Real vq(start=vq0) "q-axis voltage (pu)";
-  Real id(start=id0) "d-axis current (pu)";
-  Real iq(start=iq0) "q-axis current (pu)";
+  SI.PerUnit vd(start=vd0) "d-axis voltage";
+  SI.PerUnit vq(start=vq0) "q-axis voltage";
+  SI.PerUnit id(start=id0) "d-axis current";
+  SI.PerUnit iq(start=iq0) "q-axis current";
 protected
   SI.PerUnit pe(start=pm00) "electrical power transmitted through the air-gap";
   SI.PerUnit vf_MB=vf*V_b/Vn "field voltage on machine base";
@@ -103,12 +103,12 @@ protected
   parameter SI.PerUnit ir0=-CM.real(I0) "Init. val.";
   parameter SI.PerUnit ii0=-CM.imag(I0) "Init. val.";
 
-  // Initialize DQ-quantities (pu, machine base)
+  // Initialize DQ-quantities (machine base)
   parameter SI.PerUnit xq0 "used for setting the initial rotor angle";
   parameter SI.Angle delta0=CM.arg((Vt0 + ((ra + CM.j*xq0)*Z_MBtoSB*I0)))
     "Init. val. rotor angle";
   parameter Complex Vdq0=Vt0*CM.fromPolar(1/V_MBtoSB, (-delta0 + (C.pi/2)))
-    "Init. val (pu, machine base)";
+    "Init. val (machine base)";
   parameter Complex Idq0=I0*CM.fromPolar(1/I_MBtoSB, (-delta0 + (C.pi/2)))
     "(pu, machine base)";
   parameter SI.PerUnit vd0=CM.real(Vdq0) "Init. val.";
@@ -117,7 +117,7 @@ protected
   parameter SI.PerUnit iq0=CM.imag(Idq0) "Init. val.";
 
   parameter SI.PerUnit pm00=((vq0 + ra*iq0)*iq0 + (vd0 + ra*id0)*id0)/S_SBtoMB
-    "Init. val. (pu, system base)";
+    "Initial value (system base)";
 
 equation
   v = sqrt(p.vr^2 + p.vi^2);

--- a/OpenIPSL/Electrical/Machines/PSAT/MotorTypeI.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/MotorTypeI.mo
@@ -21,7 +21,7 @@ model MotorTypeI "Induction Machine - Order I"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.PerUnit Xm=5 "Magnetizing reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.Time Hm=3 "Inertia constant (kWs/kVA)"
+  parameter SI.Time Hm=3 "Inertia constant [Ws/VA]"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.PerUnit a=0.5 "1st coefficient of tau_m(w)"
     annotation (Dialog(group="Machine parameters"));

--- a/OpenIPSL/Electrical/Machines/PSAT/MotorTypeI.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/MotorTypeI.mo
@@ -11,25 +11,25 @@ model MotorTypeI "Induction Machine - Order I"
     final enableS_b=true);
   parameter Integer Sup=1 "Start-up control" annotation (Dialog(group=
           "Machine parameters"), choices(choice=0, choice=1));
-  parameter SI.PerUnit Rs=0.01 "Stator resistance (pu)"
+  parameter SI.PerUnit Rs=0.01 "Stator resistance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xs=0.15 "Stator reactance (pu)"
+  parameter SI.PerUnit Xs=0.15 "Stator reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Rr1=0.05 "1st cage rotor resistance (pu)"
+  parameter SI.PerUnit Rr1=0.05 "1st cage rotor resistance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xr1=0.15 "1st cage rotor reactance (pu)"
+  parameter SI.PerUnit Xr1=0.15 "1st cage rotor reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xm=5 "Magnetizing reactance (pu)"
+  parameter SI.PerUnit Xm=5 "Magnetizing reactance"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time Hm=3 "Inertia constant (kWs/kVA)"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit a=0.5 "1st coefficient of tau_m(w) (pu)"
+  parameter SI.PerUnit a=0.5 "1st coefficient of tau_m(w)"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit b=0.00 "2nd coefficient of tau_m(w) (pu)"
+  parameter SI.PerUnit b=0.00 "2nd coefficient of tau_m(w)"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit c=0.00 "3rd coefficient of tau_m(w) (pu)"
+  parameter SI.PerUnit c=0.00 "3rd coefficient of tau_m(w)"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.Time tup=0 "Start up time (s)"
+  parameter SI.Time tup=0 "Start up time"
     annotation (Dialog(group="Machine parameters"));
   SI.PerUnit v(start=v_0) "Bus voltage magnitude";
   SI.Angle anglev(start=angle_0rad) "Bus voltage angle";

--- a/OpenIPSL/Electrical/Machines/PSAT/MotorTypeIII.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/MotorTypeIII.mo
@@ -11,23 +11,23 @@ model MotorTypeIII "Induction Machine - Order III"
     final enableS_b=true);
   parameter Integer Sup=1 "Start up control" annotation (Dialog(group=
           "Machine parameters"), choices(choice=0, choice=1));
-  parameter SI.PerUnit Rs=0.01 "Stator resistance (pu)"
+  parameter SI.PerUnit Rs=0.01 "Stator resistance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xs=0.15 "Stator reactance (pu)"
+  parameter SI.PerUnit Xs=0.15 "Stator reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Rr1=0.05 "1st cage rotor resistance (pu)"
+  parameter SI.PerUnit Rr1=0.05 "1st cage rotor resistance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xr1=0.15 "1st cage rotor reactance (pu)"
+  parameter SI.PerUnit Xr1=0.15 "1st cage rotor reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xm=5 "Magnetizing reactance (pu)"
+  parameter SI.PerUnit Xm=5 "Magnetizing reactance"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time Hm=3 "Inertia constant"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit a=0.25 "1st coefficient of tau_m(w) (pu)"
+  parameter SI.PerUnit a=0.25 "1st coefficient of tau_m(w)"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit b=0.00 "2nd coefficient of tau_m(w) (pu)"
+  parameter SI.PerUnit b=0.00 "2nd coefficient of tau_m(w)"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit c=0.00 "3rd coefficient of tau_m(w) (pu)"
+  parameter SI.PerUnit c=0.00 "3rd coefficient of tau_m(w)"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time tup=0 "Start up time"
     annotation (Dialog(group="Machine parameters"));

--- a/OpenIPSL/Electrical/Machines/PSAT/MotorTypeV.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/MotorTypeV.mo
@@ -11,27 +11,27 @@ model MotorTypeV "Induction Machine - Order V"
     final enableS_b=true);
   parameter Integer Sup=1 "Start up control" annotation (Dialog(group=
           "Machine parameters"), choices(choice=0, choice=1));
-  parameter SI.PerUnit Rs=0.01 "Stator resistance (pu)"
+  parameter SI.PerUnit Rs=0.01 "Stator resistance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xs=0.15 "Stator reactance (pu)"
+  parameter SI.PerUnit Xs=0.15 "Stator reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Rr1=0.05 "1st cage rotor resistance (pu)"
+  parameter SI.PerUnit Rr1=0.05 "1st cage rotor resistance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xr1=0.15 "1st cage rotor reactance (pu)"
+  parameter SI.PerUnit Xr1=0.15 "1st cage rotor reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Rr2=0.001 "2nd cage rotor resistance (pu)"
+  parameter SI.PerUnit Rr2=0.001 "2nd cage rotor resistance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xr2=0.04 "2nd cage rotor reactance (pu)"
+  parameter SI.PerUnit Xr2=0.04 "2nd cage rotor reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xm=5 "Magnetizing reactance (pu)"
+  parameter SI.PerUnit Xm=5 "Magnetizing reactance"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time Hm=3 "Inertia constant"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit a=0.13 "1st coefficient of tau_m(w) (pu)"
+  parameter SI.PerUnit a=0.13 "1st coefficient of tau_m(w)"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit b=0.02 "2nd coefficient of tau_m(w) (pu)"
+  parameter SI.PerUnit b=0.02 "2nd coefficient of tau_m(w)"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit c=0.024 "3rd coefficient of tau_m(w) (pu)"
+  parameter SI.PerUnit c=0.024 "3rd coefficient of tau_m(w)"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time tup=0 "Start up time"
     annotation (Dialog(group="Machine parameters"));

--- a/OpenIPSL/Electrical/Machines/PSAT/Order2.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/Order2.mo
@@ -6,7 +6,7 @@ protected
   parameter Real c1=ra*K "scaled ra";
   parameter Real c2=x1d*K "scaled x'd";
   parameter Real c3=x1d*K "scaled x'd";
-  parameter SI.PerUnit vf00=V_MBtoSB*(vq0 + ra*iq0 + x1d*id0) "Init. val. (pu, SB)";
+  parameter SI.PerUnit vf00=V_MBtoSB*(vq0 + ra*iq0 + x1d*id0) "Initial value (SB)";
 equation
   id = -c1*vd - c3*vq + vf_MB*c3;
   iq = c2*vd - c1*vq + vf_MB*c1;

--- a/OpenIPSL/Electrical/Machines/PSAT/Order3.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/Order3.mo
@@ -1,20 +1,20 @@
 within OpenIPSL.Electrical.Machines.PSAT;
 model Order3 "Third Order Synchronous Machine with Inputs and Outputs"
   extends BaseClasses.baseMachine(vf(start=vf00), xq0=xq);
-  parameter SI.PerUnit xd "d-axis synchronous reactance (pu)"
+  parameter SI.PerUnit xd "d-axis synchronous reactance"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time T1d0 "d-axis open circuit transient time constant"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit xq "q-axis synchronous reactance (pu)"
+  parameter SI.PerUnit xq "q-axis synchronous reactance"
     annotation (Dialog(group="Machine parameters"));
-  SI.PerUnit e1q(start=e1q0) "q-axis transient voltage (pu)";
+  SI.PerUnit e1q(start=e1q0) "q-axis transient voltage";
 
 protected
   parameter Real K=1/(ra^2 + xq*x1d) "a constant for scaling";
   parameter Real c1=ra*K "scaled ra";
   parameter Real c2=x1d*K "scaled x'd";
   parameter Real c3=xq*K " scaled xq";
-  parameter SI.PerUnit vf00=V_MBtoSB*(e1q0 + (xd - x1d)*id0) "Init. val. (pu, SB)";
+  parameter SI.PerUnit vf00=V_MBtoSB*(e1q0 + (xd - x1d)*id0) "Inititial value (system base)";
   parameter Real e1q0=vq0 + ra*iq0 + x1d*id0 "Initialitation";
 initial equation
   der(e1q) = 0;

--- a/OpenIPSL/Electrical/Machines/PSAT/Order4.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/Order4.mo
@@ -14,7 +14,7 @@ model Order4 "Fourth Order Synchronous Machine with Inputs and Outputs"
   SI.PerUnit e1q(start=e1q0) "q-axis transient voltage";
   SI.PerUnit e1d(start=e1d0) "d-axis transient voltage";
 protected
-  parameter SI.PerUnit vf00=V_MBtoSB*(e1q0 + (xd - x1d)*id0) "Initial value (systemn base)";
+  parameter SI.PerUnit vf00=V_MBtoSB*(e1q0 + (xd - x1d)*id0) "Initial value (system base)";
   parameter SI.PerUnit e1q0=vq0 + ra*iq0 + x1d*id0 "Initialization";
   parameter SI.PerUnit e1d0=vd0 + ra*id0 - x1q*iq0 "Initialization";
 initial equation

--- a/OpenIPSL/Electrical/Machines/PSAT/Order4.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/Order4.mo
@@ -1,20 +1,20 @@
 within OpenIPSL.Electrical.Machines.PSAT;
 model Order4 "Fourth Order Synchronous Machine with Inputs and Outputs"
   extends BaseClasses.baseMachine(vf(start=vf00), xq0=xq);
-  parameter SI.PerUnit xd=1.9 "d-axis synchronous reactance (pu)"
+  parameter SI.PerUnit xd=1.9 "d-axis synchronous reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit xq=1.7 "q-axis synchronous reactance (pu)"
+  parameter SI.PerUnit xq=1.7 "q-axis synchronous reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit x1q=0.5 "q-axis transient reactance (pu)"
+  parameter SI.PerUnit x1q=0.5 "q-axis transient reactance"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time T1d0=8 "d-axis open circuit transient time constant"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time T1q0=0.8 "q-axis open circuit transient time constant"
     annotation (Dialog(group="Machine parameters"));
-  SI.PerUnit e1q(start=e1q0) "q-axis transient voltage (pu)";
-  SI.PerUnit e1d(start=e1d0) "d-axis transient voltage (pu)";
+  SI.PerUnit e1q(start=e1q0) "q-axis transient voltage";
+  SI.PerUnit e1d(start=e1d0) "d-axis transient voltage";
 protected
-  parameter SI.PerUnit vf00=V_MBtoSB*(e1q0 + (xd - x1d)*id0) "Init. val. (pu, SB)";
+  parameter SI.PerUnit vf00=V_MBtoSB*(e1q0 + (xd - x1d)*id0) "Initial value (systemn base)";
   parameter SI.PerUnit e1q0=vq0 + ra*iq0 + x1d*id0 "Initialization";
   parameter SI.PerUnit e1d0=vd0 + ra*id0 - x1q*iq0 "Initialization";
 initial equation

--- a/OpenIPSL/Electrical/Machines/PSAT/Order5_Type1.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/Order5_Type1.mo
@@ -1,11 +1,11 @@
 within OpenIPSL.Electrical.Machines.PSAT;
 model Order5_Type1
   extends BaseClasses.baseMachine(vf(start=vf00), xq0=xq);
-  parameter SI.PerUnit xd=1.9 "d-axis synchronous reactance (pu)"
+  parameter SI.PerUnit xd=1.9 "d-axis synchronous reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit xq=1.7 "q-axis synchronous reactance (pu)"
+  parameter SI.PerUnit xq=1.7 "q-axis synchronous reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit x1q=0.5 "q-axis transient reactance (pu)"
+  parameter SI.PerUnit x1q=0.5 "q-axis transient reactance"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time T1d0=8 "d-axis open circuit transient time constant"
     annotation (Dialog(group="Machine parameters"));
@@ -18,7 +18,7 @@ model Order5_Type1
   SI.PerUnit e1d(start=e1d0) "d-axis transient voltage";
   SI.PerUnit e2d(start=e2d0) "d-axis sub-transient voltage";
 protected
-  parameter SI.PerUnit vf00=V_MBtoSB*(e1q0 + (xd - x1d)*id0) "Init. val. (pu, SB)";
+  parameter SI.PerUnit vf00=V_MBtoSB*(e1q0 + (xd - x1d)*id0) "Init. val. [pu, SB]";
   parameter SI.PerUnit e1q0=vq0 + ra*iq0 + x1d*id0 "Initialization";
   parameter SI.PerUnit e1d0=vd0 + ra*id0 - x1q*iq0 "Initialization*";
   parameter SI.PerUnit e2d0=vd0 + ra*id0 - x1q*iq0 "Initialization";

--- a/OpenIPSL/Electrical/Machines/PSAT/Order5_Type2.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/Order5_Type2.mo
@@ -1,13 +1,13 @@
 within OpenIPSL.Electrical.Machines.PSAT;
 model Order5_Type2
   extends BaseClasses.baseMachine(vf(start=vf00), xq0=xq);
-  parameter SI.PerUnit xd=1.9 "d-axis synchronous reactance (pu)"
+  parameter SI.PerUnit xd=1.9 "d-axis synchronous reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit xq=1.7 "q-axis synchronous reactance (pu)"
+  parameter SI.PerUnit xq=1.7 "q-axis synchronous reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit x2d=0.204 "d-axis sub-transient reactance (pu)"
+  parameter SI.PerUnit x2d=0.204 "d-axis sub-transient reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit x2q=0.3 "q-axis sub-transient reactance (pu)"
+  parameter SI.PerUnit x2q=0.3 "q-axis sub-transient reactance"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time T1d0=8 "d-axis open circuit transient time constant"
     annotation (Dialog(group="Machine parameters"));
@@ -27,7 +27,7 @@ protected
   parameter SI.PerUnit K2=x1d - x2d + (T2d0*x2d*(xd - x1d))/(T1d0*x1d);
   parameter SI.PerUnit e1q0=(-K1*Taa/T1d0*id0) + (1 - Taa/T1d0)*(e2q0 + K2*id0);
   parameter SI.PerUnit vf00=V_MBtoSB*(K1*id0 + e1q0)/(1 - Taa/T1d0)
-    "Init. val. (pu, SB)";
+    "Initial value (system base)";
 initial equation
   //der(e1q) = 0;
   der(e2q) = 0;

--- a/OpenIPSL/Electrical/Machines/PSAT/Order6.mo
+++ b/OpenIPSL/Electrical/Machines/PSAT/Order6.mo
@@ -1,25 +1,25 @@
 within OpenIPSL.Electrical.Machines.PSAT;
 model Order6
   extends BaseClasses.baseMachine(vf(start=vf00), xq0=xq);
-  parameter SI.PerUnit xd=1.9 "d-axis synchronous reactance (pu)"
+  parameter SI.PerUnit xd=1.9 "d-axis synchronous reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit xq=1.7 "q-axis synchronous reactance (pu)"
+  parameter SI.PerUnit xq=1.7 "q-axis synchronous reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit x1q=0.5 "q-axis transient reactance (pu)"
+  parameter SI.PerUnit x1q=0.5 "q-axis transient reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit x2d=0.204 "d-axis sub-transient reactance (pu)"
+  parameter SI.PerUnit x2d=0.204 "d-axis sub-transient reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit x2q=0.3 "q-axis sub-transient reactance (pu)"
+  parameter SI.PerUnit x2q=0.3 "q-axis sub-transient reactance"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.Time T1d0=8 "d-axis open circuit transient time constant (s)"
+  parameter SI.Time T1d0=8 "d-axis open circuit transient time constant"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.Time T1q0=0.8 "q-axis open circuit transient time constant (s)"
+  parameter SI.Time T1q0=0.8 "q-axis open circuit transient time constant"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.Time T2d0=0.04 "d-axis open circuit sub-transient time constant (s)"
+  parameter SI.Time T2d0=0.04 "d-axis open circuit sub-transient time constant"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.Time T2q0=0.02 "q-axis open circuit sub-transient time constant (s)"
+  parameter SI.Time T2q0=0.02 "q-axis open circuit sub-transient time constant"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.Time Taa=2e-3 "d-axis additional leakage time constant (s)"
+  parameter SI.Time Taa=2e-3 "d-axis additional leakage time constant"
     annotation (Dialog(group="Machine parameters"));
 
   SI.PerUnit e1q(start=e1q0, fixed=true) "q-axis transient voltage";

--- a/OpenIPSL/Electrical/Machines/PSSE/BaseClasses/baseMachine.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/BaseClasses/baseMachine.mo
@@ -71,7 +71,7 @@ partial model baseMachine
     annotation (Placement(transformation(extent={{100,20},{120,40}})));
   RealOutput ISORCE "Machine source current (pu)"
     annotation (Placement(transformation(extent={{100,-80},{120,-60}})));
-  RealOutput ANGLE "Machine relative rotor angle (deg)"
+  RealOutput ANGLE "Machine relative rotor angle"
     annotation (Placement(transformation(extent={{100,80},{120,100}})));
   RealOutput XADIFD "Machine field current (pu)" annotation (Placement(
         transformation(

--- a/OpenIPSL/Electrical/Machines/PSSE/BaseClasses/baseMachine.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/BaseClasses/baseMachine.mo
@@ -55,43 +55,43 @@ partial model baseMachine
     ir(start=ir0),
     ii(start=ii0))
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
-  RealOutput SPEED "Machine speed deviation from nominal (pu)"
+  RealOutput SPEED "Machine speed deviation from nominal [pu]"
     annotation (Placement(transformation(extent={{100,60},{120,80}})));
-  RealInput PMECH "Turbine mechanical power (pu, machine base)"
+  RealInput PMECH "Turbine mechanical power (machine base)"
     annotation (Placement(transformation(extent={{-140,30},{-100,70}})));
-  RealOutput PMECH0 "Initial value of machine electrical power (pu, machine base)"
+  RealOutput PMECH0 "Initial value of machine electrical power (machine base)"
     annotation (Placement(transformation(extent={{100,40},{120,60}})));
-  RealOutput ETERM(start=v_0) "Machine terminal voltage (pu)"
+  RealOutput ETERM(start=v_0) "Machine terminal voltage [pu]"
     annotation (Placement(transformation(extent={{100,-40},{120,-20}})));
-  RealInput EFD "Generator main field voltage (pu)"
+  RealInput EFD "Generator main field voltage [pu]"
     annotation (Placement(transformation(extent={{-140,-70},{-100,-30}})));
-  RealOutput EFD0 "Initial generator main field voltage (pu)"
+  RealOutput EFD0 "Initial generator main field voltage [pu]"
     annotation (Placement(transformation(extent={{100,-60},{120,-40}})));
-  RealOutput PELEC(start=p0) "Machine electrical power (pu, machine base)"
+  RealOutput PELEC(start=p0) "Machine electrical power (machine base)"
     annotation (Placement(transformation(extent={{100,20},{120,40}})));
-  RealOutput ISORCE "Machine source current (pu)"
+  RealOutput ISORCE "Machine source current [pu]"
     annotation (Placement(transformation(extent={{100,-80},{120,-60}})));
   RealOutput ANGLE "Machine relative rotor angle"
     annotation (Placement(transformation(extent={{100,80},{120,100}})));
-  RealOutput XADIFD "Machine field current (pu)" annotation (Placement(
+  RealOutput XADIFD "Machine field current [pu]" annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         origin={110,-90}), iconTransformation(
         extent={{-10,-10},{10,10}},
         origin={110,-90})));
-  SI.PerUnit w(start=w0) "Machine speed deviation (pu)";
+  SI.PerUnit w(start=w0) "Machine speed deviation";
   SI.Angle delta "Rotor angle";
-  SI.PerUnit Vt(start=v_0) "Bus voltage magnitude (pu)";
+  SI.PerUnit Vt(start=v_0) "Bus voltage magnitude";
   SI.Angle anglev(start=angle_0rad) "Bus voltage angle";
-  SI.PerUnit I(start=sqrt(ir0^2 + ii0^2)) "Terminal current magnitude (pu)";
+  SI.PerUnit I(start=sqrt(ir0^2 + ii0^2)) "Terminal current magnitude";
   SI.Angle anglei(start=atan2(ii0, ir0)) "Terminal current angle";
-  SI.PerUnit P(start=P_0/S_b) "Active power (pu, system base)";
-  SI.PerUnit Q(start=Q_0/S_b) "Reactive power (pu, system base)";
-  SI.PerUnit Te "Electrical torque (pu)";
-  SI.PerUnit id "d-axis armature current (pu)";
-  SI.PerUnit iq "q-axis armature current (pu)";
-  SI.PerUnit ud "d-axis terminal voltage (pu)";
-  SI.PerUnit uq "q-axis terminal voltage (pu)";
+  SI.PerUnit P(start=P_0/S_b) "Active power (system base)";
+  SI.PerUnit Q(start=Q_0/S_b) "Reactive power (system base)";
+  SI.PerUnit Te "Electrical torque [pu]";
+  SI.PerUnit id "d-axis armature current [pu]";
+  SI.PerUnit iq "q-axis armature current [pu]";
+  SI.PerUnit ud "d-axis terminal voltage [pu]";
+  SI.PerUnit uq "q-axis terminal voltage [pu]";
 protected
   parameter SI.AngularVelocity w_b=2*C.pi*fn "System base speed";
   parameter Real CoB=M_b/S_b;
@@ -100,12 +100,12 @@ protected
   parameter SI.PerUnit vi0=v_0*sin(angle_0rad)
     "Imaginary component of initial terminal voltage";
   parameter SI.PerUnit ir0=-CoB*(p0*vr0 + q0*vi0)/(vr0^2 + vi0^2)
-    "Real component of initial armature current (pu, system base)";
+    "Real component of initial armature current (system base)";
   parameter SI.PerUnit ii0=-CoB*(p0*vi0 - q0*vr0)/(vr0^2 + vi0^2)
-    "Imaginary component of initial armature current (pu, system base)";
-  parameter SI.PerUnit p0=P_0/M_b "Initial active power generation (pu, machine base)";
+    "Imaginary component of initial armature current (system base)";
+  parameter SI.PerUnit p0=P_0/M_b "Initial active power generation (machine base)";
   parameter SI.PerUnit q0=Q_0/M_b
-    "Initial reactive power generation (pu, machine base)";
+    "Initial reactive power generation (machine base)";
 equation
   //Interfacing outputs with the internal variables
   ANGLE = delta;

--- a/OpenIPSL/Electrical/Machines/PSSE/GENROE.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/GENROE.mo
@@ -22,24 +22,24 @@ model GENROE "ROUND ROTOR GENERATOR MODEL (EXPONENTIAL SATURATION)"
     uq(start=uq0),
     Te(start=pm0));
   //Machine parameters
-  parameter SI.PerUnit Xpq "Sub-transient reactance (pu)"
+  parameter SI.PerUnit Xpq "Sub-transient reactance"
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time Tpq0 "q-axis transient open-circuit time constant"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xpp=Xppd "Sub-transient reactance (pu)"
+  parameter SI.PerUnit Xpp=Xppd "Sub-transient reactance"
     annotation (Dialog(group="Machine parameters"));
-  SI.PerUnit Epd(start=Epd0) "d-axis voltage behind transient reactance (pu)";
-  SI.PerUnit Epq(start=Epq0) "q-axis voltage behind transient reactance (pu)";
-  SI.PerUnit PSIkd(start=PSIkd0) "d-axis rotor flux linkage (pu)";
-  SI.PerUnit PSIkq(start=PSIkq0) "q-axis rotor flux linkage (pu)";
+  SI.PerUnit Epd(start=Epd0) "d-axis voltage behind transient reactance";
+  SI.PerUnit Epq(start=Epq0) "q-axis voltage behind transient reactance";
+  SI.PerUnit PSIkd(start=PSIkd0) "d-axis rotor flux linkage";
+  SI.PerUnit PSIkq(start=PSIkq0) "q-axis rotor flux linkage";
   //State variables
-  SI.PerUnit PSId(start=PSId0) "d-axis flux linkage (pu)";
-  SI.PerUnit PSIq(start=PSIq0) "q-axis flux linkage (pu)";
-  SI.PerUnit PSIppd(start=PSIppd0) "d-axis subtransient flux linkage (pu)";
-  SI.PerUnit PSIppq(start=PSIppq0) "q-axis subtransient flux linkage (pu)";
-  SI.PerUnit PSIpp "Air-gap flux (pu)";
-  SI.PerUnit XadIfd(start=efd0) "d-axis machine field current (pu)";
-  SI.PerUnit XaqIlq(start=0) "q-axis Machine field current (pu)";
+  SI.PerUnit PSId(start=PSId0) "d-axis flux linkage";
+  SI.PerUnit PSIq(start=PSIq0) "q-axis flux linkage";
+  SI.PerUnit PSIppd(start=PSIppd0) "d-axis subtransient flux linkage";
+  SI.PerUnit PSIppq(start=PSIppq0) "q-axis subtransient flux linkage";
+  SI.PerUnit PSIpp "Air-gap flux";
+  SI.PerUnit XadIfd(start=efd0) "d-axis machine field current";
+  SI.PerUnit XaqIlq(start=0) "q-axis Machine field current";
 protected
   parameter Complex Zs=R_a + j*Xpp "Equivalent impedance";
   parameter Complex VT=v_0*cos(angle_0rad) + j*v_0*sin(angle_0rad)

--- a/OpenIPSL/Electrical/Machines/PSSE/GENROU.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/GENROU.mo
@@ -20,24 +20,24 @@ model GENROU "ROUND ROTOR GENERATOR MODEL (QUADRATIC SATURATION)"
     uq(start=uq0),
     Te(start=pm0));
   //Machine parameters
-  parameter SI.PerUnit Xpq "q-axis transient reactance (pu)"
+  parameter SI.PerUnit Xpq "q-axis transient reactance "
     annotation (Dialog(group="Machine parameters"));
   parameter SI.Time Tpq0 "q-axis transient open-circuit time constant"
     annotation (Dialog(group="Machine parameters"));
-  parameter SI.PerUnit Xpp=Xppd "Sub-transient reactance (pu)"
+  parameter SI.PerUnit Xpp=Xppd "Sub-transient reactance "
     annotation (Dialog(group="Machine parameters"));
-  SI.PerUnit Epd(start=Epd0) "d-axis voltage behind transient reactance (pu)";
+  SI.PerUnit Epd(start=Epd0) "d-axis voltage behind transient reactance ";
   SI.PerUnit Epq(start=Epq0) "q-axis voltage behind transient reactance ";
-  SI.PerUnit PSIkd(start=PSIkd0) "d-axis rotor flux linkage (pu)";
-  SI.PerUnit PSIkq(start=PSIkq0) "q-axis rotor flux linkage (pu)";
+  SI.PerUnit PSIkd(start=PSIkd0) "d-axis rotor flux linkage ";
+  SI.PerUnit PSIkq(start=PSIkq0) "q-axis rotor flux linkage ";
   //State variables
-  SI.PerUnit PSId(start=PSId0) "d-axis flux linkage (pu)";
-  SI.PerUnit PSIq(start=PSIq0) "q-axis flux linkage (pu)";
-  SI.PerUnit PSIppd(start=PSIppd0) "d-axis subtransient flux linkage (pu)";
-  SI.PerUnit PSIppq(start=PSIppq0) "q-axis subtransient flux linkage (pu)";
-  SI.PerUnit PSIpp "Air-gap flux (pu)";
-  SI.PerUnit XadIfd(start=efd0) "d-axis machine field current (pu)";
-  SI.PerUnit XaqIlq(start=0) "q-axis Machine field current (pu)";
+  SI.PerUnit PSId(start=PSId0) "d-axis flux linkage ";
+  SI.PerUnit PSIq(start=PSIq0) "q-axis flux linkage ";
+  SI.PerUnit PSIppd(start=PSIppd0) "d-axis subtransient flux linkage ";
+  SI.PerUnit PSIppq(start=PSIppq0) "q-axis subtransient flux linkage ";
+  SI.PerUnit PSIpp "Air-gap flux ";
+  SI.PerUnit XadIfd(start=efd0) "d-axis machine field current ";
+  SI.PerUnit XaqIlq(start=0) "q-axis Machine field current ";
 protected
   parameter Complex Zs=R_a + j*Xpp "Equivalent impedance";
   parameter Complex VT=v_0*cos(angle_0rad) + j*v_0*sin(angle_0rad)
@@ -88,12 +88,12 @@ protected
   parameter SI.PerUnit vi0=v_0*sin(angle_0rad)
     "Imaginary component of initial terminal voltage";
   parameter SI.PerUnit ir0=-CoB*(p0*vr0 + q0*vi0)/(vr0^2 + vi0^2)
-    "Real component of initial armature current (pu, system base)";
+    "Real component of initial armature current (system base)";
   parameter SI.PerUnit ii0=-CoB*(p0*vi0 - q0*vr0)/(vr0^2 + vi0^2)
-    "Imaginary component of initial armature current (pu, system base)";
+    "Imaginary component of initial armature current (system base)";
   //Initialization mechanical power and field voltage.
   parameter SI.PerUnit pm0=p0 + R_a*iq0*iq0 + R_a*id0*id0
-    "Initial mechanical power (pu, machine base)";
+    "Initial mechanical power (machine base)";
   parameter SI.PerUnit efd0=dsat*PSIppd0 + PSIppd0 + (Xpd - Xpp)*id0 + (Xd - Xpd)*id0
     "Initial field voltage magnitude";
   parameter SI.PerUnit Epq0=PSIkd0 + (Xpd - Xl)*id0;

--- a/OpenIPSL/Electrical/Machines/PSSE/GENSAE.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/GENSAE.mo
@@ -22,14 +22,14 @@ model GENSAE "SALIENT POLE GENERATOR MODEL (EXPONENTIAL SATURATION)"
     ud(start=ud0),
     uq(start=uq0),
     Te(start=pm0));
-  SI.PerUnit Epq(start=Epq0) "q-axis voltage behind transient reactance (pu)";
-  SI.PerUnit PSIkd(start=PSIkd0) "d-axis rotor flux linkage (pu)";
-  SI.PerUnit PSIppq(start=PSIppq0) "q-axis subtransient flux linkage (pu)";
-  SI.PerUnit PSIppd(start=PSIppd0) "d-axis subtransient flux linkage (pu)";
-  SI.PerUnit PSId(start=PSId0) "d-axis flux linkage (pu)";
-  SI.PerUnit PSIq(start=PSIq0) "q-axis flux linkage (pu)";
-  SI.PerUnit XadIfd(start=efd0) "Machine field current (pu)";
-  SI.PerUnit PSIpp "Air-gap flux (pu)";
+  SI.PerUnit Epq(start=Epq0) "q-axis voltage behind transient reactance";
+  SI.PerUnit PSIkd(start=PSIkd0) "d-axis rotor flux linkage";
+  SI.PerUnit PSIppq(start=PSIppq0) "q-axis subtransient flux linkage";
+  SI.PerUnit PSIppd(start=PSIppd0) "d-axis subtransient flux linkage";
+  SI.PerUnit PSId(start=PSId0) "d-axis flux linkage";
+  SI.PerUnit PSIq(start=PSIq0) "q-axis flux linkage";
+  SI.PerUnit XadIfd(start=efd0) "Machine field current";
+  SI.PerUnit PSIpp "Air-gap flux";
 protected
   parameter Complex Zs=R_a + j*Xppd "Equivalent impedance";
   parameter Complex Is=real(It + VT/Zs) + j*imag(It + VT/Zs);

--- a/OpenIPSL/Electrical/Machines/PSSE/GENSAL.mo
+++ b/OpenIPSL/Electrical/Machines/PSSE/GENSAL.mo
@@ -22,13 +22,13 @@ model GENSAL "SALIENT POLE GENERATOR MODEL (QUADRATIC SATURATION ON D-AXIS)"
     ud(start=ud0),
     uq(start=uq0),
     Te(start=pm0));
-  SI.PerUnit Epq(start=Epq0) "q-axis voltage behind transient reactance (pu)";
-  SI.PerUnit PSIkd(start=PSIkd0) "d-axis rotor flux linkage (pu)";
-  SI.PerUnit PSIppq(start=PSIppq0) "q-axis subtransient flux linkage (pu)";
-  SI.PerUnit PSIppd(start=PSIppd0) "d-axis subtransient flux linkage (pu)";
-  SI.PerUnit PSId(start=PSId0) "d-axis flux linkage (pu)";
-  SI.PerUnit PSIq(start=PSIq0) "q-axis flux linkage (pu)";
-  SI.PerUnit XadIfd(start=efd0) "Machine field current (pu)";
+  SI.PerUnit Epq(start=Epq0) "q-axis voltage behind transient reactance";
+  SI.PerUnit PSIkd(start=PSIkd0) "d-axis rotor flux linkage";
+  SI.PerUnit PSIppq(start=PSIppq0) "q-axis subtransient flux linkage";
+  SI.PerUnit PSIppd(start=PSIppd0) "d-axis subtransient flux linkage";
+  SI.PerUnit PSId(start=PSId0) "d-axis flux linkage";
+  SI.PerUnit PSIq(start=PSIq0) "q-axis flux linkage";
+  SI.PerUnit XadIfd(start=efd0) "Machine field current";
 protected
   parameter Complex Zs=R_a + j*Xppd "Equivalent impedance";
   parameter Complex Is=real(It + VT/Zs) + j*imag(It + VT/Zs);
@@ -70,7 +70,7 @@ protected
   parameter SI.PerUnit efd0=Epq0*(1 + dsat) + (Xd - Xpd)*id0
     "Initial field voltage magnitude";
   parameter SI.PerUnit pm0=p0 + R_a*iq0*iq0 + R_a*id0*id0
-    "Initial mechanical power (pu, machine base)";
+    "Initial mechanical power (machine base)";
   // Constants
   parameter Real K1d=(Xpd - Xppd)*(Xd - Xpd)/(Xpd - Xl)^2;
   parameter Real K2d=(Xpd - Xl)*(Xppd - Xl)/(Xpd - Xppd);

--- a/OpenIPSL/Electrical/SystemBase.mo
+++ b/OpenIPSL/Electrical/SystemBase.mo
@@ -1,7 +1,7 @@
 within OpenIPSL.Electrical;
 record SystemBase "System Base Definition"
   parameter SI.ApparentPower S_b(displayUnit="MVA")=100e6 "System base";
-  parameter Modelica.SIunits.Frequency fn=50 "System frequency";
+  parameter SI.Frequency fn=50 "System frequency";
   annotation (
     Icon(coordinateSystem(
         preserveAspectRatio=false,

--- a/OpenIPSL/NonElectrical/Continuous/DerivativeLag.mo
+++ b/OpenIPSL/NonElectrical/Continuous/DerivativeLag.mo
@@ -2,7 +2,7 @@ within OpenIPSL.NonElectrical.Continuous;
 block DerivativeLag "Derivative lag transfer function block"
   extends Modelica.Blocks.Interfaces.SISO;
   parameter Real K "Gain";
-  parameter Modelica.SIunits.Time T "Time constant";
+  parameter SI.Time T "Time constant";
   parameter Real y_start "Output start value"
     annotation (Dialog(group="Initialization"));
   parameter Real x_start=0 "Start value of state variable"
@@ -17,9 +17,9 @@ block DerivativeLag "Derivative lag transfer function block"
     a={T_dummy,1})
     annotation (Placement(transformation(extent={{-8,-10},{12,10}})));
 protected
-  parameter Modelica.SIunits.Time T_dummy=if abs(T) < Modelica.Constants.eps
+  parameter SI.Time T_dummy=if abs(T) < Modelica.Constants.eps
        then 1000 else T "Lead time constant";
-  parameter Modelica.SIunits.Time K_dummy=if abs(K) < Modelica.Constants.eps
+  parameter SI.Time K_dummy=if abs(K) < Modelica.Constants.eps
        then 1 else K "Lead time constant";
 equation
   if abs(par1.y) < Modelica.Constants.eps then

--- a/OpenIPSL/NonElectrical/Continuous/LeadLag.mo
+++ b/OpenIPSL/NonElectrical/Continuous/LeadLag.mo
@@ -2,8 +2,8 @@ within OpenIPSL.NonElectrical.Continuous;
 block LeadLag "Lead-Lag filter"
   extends Modelica.Blocks.Interfaces.SISO;
   parameter Real K "Gain";
-  parameter Modelica.SIunits.Time T1 "Lead time constant";
-  parameter Modelica.SIunits.Time T2 "Lag time constant";
+  parameter SI.Time T1 "Lead time constant";
+  parameter SI.Time T2 "Lag time constant";
   parameter Real y_start "Output start value"
     annotation (Dialog(group="Initialization"));
   parameter Real x_start=0 "Start value of state variable"
@@ -20,7 +20,7 @@ block LeadLag "Lead-Lag filter"
     x_start={x_start})
     annotation (Placement(transformation(extent={{-8,-10},{12,10}})));
 protected
-  parameter Modelica.SIunits.Time T2_dummy=if abs(T1 - T2) < Modelica.Constants.eps
+  parameter SI.Time T2_dummy=if abs(T1 - T2) < Modelica.Constants.eps
        then 1000 else T2 "Lead time constant";
 equation
   if abs(par1.y - par2.y) < Modelica.Constants.eps then

--- a/OpenIPSL/NonElectrical/Continuous/LeadLagLim.mo
+++ b/OpenIPSL/NonElectrical/Continuous/LeadLagLim.mo
@@ -2,8 +2,8 @@ within OpenIPSL.NonElectrical.Continuous;
 block LeadLagLim "Lead-Lag filter with a non-windup limiter"
   extends Modelica.Blocks.Interfaces.SISO;
   parameter Real K "Gain";
-  parameter Modelica.SIunits.Time T1 "Lead time constant";
-  parameter Modelica.SIunits.Time T2 "Lag time constant";
+  parameter SI.Time T1 "Lead time constant";
+  parameter SI.Time T2 "Lag time constant";
   parameter Real outMax "Maximum output value";
   parameter Real outMin "Minimum output value";
   parameter Real y_start "Output start value"

--- a/OpenIPSL/NonElectrical/Continuous/SimpleLag.mo
+++ b/OpenIPSL/NonElectrical/Continuous/SimpleLag.mo
@@ -5,7 +5,7 @@ block SimpleLag "First order lag transfer function block"
     annotation (Placement(transformation(extent={{-58,32},{-38,52}})));
   Real state(start=y_start);
   parameter Real K "Gain";
-  parameter Modelica.SIunits.Time T "Lag time constant";
+  parameter SI.Time T "Lag time constant";
   parameter Real y_start "Output start value";
 protected
   parameter Real T_mod=if T < Modelica.Constants.eps then 1000 else T;

--- a/OpenIPSL/NonElectrical/Continuous/SimpleLagLim.mo
+++ b/OpenIPSL/NonElectrical/Continuous/SimpleLagLim.mo
@@ -6,7 +6,7 @@ block SimpleLagLim
     annotation (Placement(transformation(extent={{-58,32},{-38,52}})));
   Real state;
   parameter Real K "Gain";
-  parameter Modelica.SIunits.Time T "Lag time constant";
+  parameter SI.Time T "Lag time constant";
   parameter Real y_start "Output start value";
   parameter Real outMax "Maximum output value";
   parameter Real outMin "Minimum output value";

--- a/OpenIPSL/NonElectrical/Continuous/SimpleLagLimVar.mo
+++ b/OpenIPSL/NonElectrical/Continuous/SimpleLagLimVar.mo
@@ -15,7 +15,7 @@ block SimpleLagLimVar
   Modelica.Blocks.Sources.RealExpression const(y=T)
     annotation (Placement(transformation(extent={{-58,32},{-38,52}})));
   parameter Real K "Gain";
-  parameter Modelica.SIunits.Time T "Lag time constant";
+  parameter SI.Time T "Lag time constant";
   parameter Real y_start "Output start value";
   parameter Real T_mod=if T < Modelica.Constants.eps then 1000 else T;
   Real state;

--- a/OpenIPSL/NonElectrical/Continuous/SimpleLagRateLimBlock.mo
+++ b/OpenIPSL/NonElectrical/Continuous/SimpleLagRateLimBlock.mo
@@ -3,7 +3,7 @@ block SimpleLagRateLimBlock
   "First order lag transfer function block with a non windup limiter, rate limits and blocking input"
   extends Modelica.Blocks.Interfaces.SISO(y(start=y_start));
   parameter Real K "Gain" annotation (Evaluate=false);
-  parameter Modelica.SIunits.Time T "Lag time constant"
+  parameter SI.Time T "Lag time constant"
     annotation (Evaluate=false);
   parameter Real y_start "Output start value"
     annotation (Dialog(group="Initialization"));

--- a/OpenIPSL/NonElectrical/Continuous/SimpleLagRateLimVar.mo
+++ b/OpenIPSL/NonElectrical/Continuous/SimpleLagRateLimVar.mo
@@ -2,7 +2,7 @@ within OpenIPSL.NonElectrical.Continuous;
 block SimpleLagRateLimVar
   "First order lag transfer function block with a non windup limiter, rate limits, variable output limits and blocking input"
   extends Modelica.Blocks.Interfaces.SISO;
-  parameter Modelica.SIunits.Time T "Lag time constant"
+  parameter SI.Time T "Lag time constant"
     annotation (Evaluate=false);
   parameter Real y_start "Output start value"
     annotation (Dialog(group="Initialization"));

--- a/OpenIPSL/NonElectrical/Continuous/SimpleLead.mo
+++ b/OpenIPSL/NonElectrical/Continuous/SimpleLead.mo
@@ -2,7 +2,7 @@ within OpenIPSL.NonElectrical.Continuous;
 block SimpleLead "First order lead transfer function block"
   extends Modelica.Blocks.Interfaces.SISO;
   parameter Real K "Gain" annotation (Evaluate=false);
-  parameter Modelica.SIunits.Time T "Lead time constant"
+  parameter SI.Time T "Lead time constant"
     annotation (Evaluate=false);
   parameter Real y_start "Output start value"
     annotation (Dialog(group="Initialization"));

--- a/OpenIPSL/Resources/Scripts/ConvertOpenIPSL_from_1.5.0_to_2.0.0.mos
+++ b/OpenIPSL/Resources/Scripts/ConvertOpenIPSL_from_1.5.0_to_2.0.0.mos
@@ -186,13 +186,13 @@ convertModifiers("OpenIPSL.Electrical.Banks.Simulink.Shunt",
 
  // custom types are no longer used, conversion is not perfect since it does not take care of the scaling
 convertClass("OpenIPSL.Types.ActivePowerMega",
-             "Modelica.SIunits.ActivePower");
+             "SI.ActivePower");
 convertClass("OpenIPSL.Types.ApparentPower",
-             "Modelica.SIunits.ApparentPower");
+             "SI.ApparentPower");
 convertClass("OpenIPSL.Types.ReactivePowerMega",
-             "Modelica.SIunits.ReactivePower");
+             "SI.ReactivePower");
 convertClass("OpenIPSL.Types.VoltageKilo",
-"Modelica.SIunits.Voltage");
+"SI.Voltage");
 
 
 // PSAT loads


### PR DESCRIPTION
When a unit is defined via the type then having it also hard coded in the description string might lead to problems. E.g., defining an angle as deg when the tool decides to display it as rad can be confusing. This PR tries to clean this up. The classes inside Wind and Solar were not fixed since they need to be fixed and cleaned up properly at a later point anyway. The same goes for the FACTS package. 