### PR TITLE
Replaces custom LV and HV gate definitions with MSL blocks

### DIFF
--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESAC1A.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESAC1A.mo
@@ -24,36 +24,36 @@ model ESAC1A "AC1A Excitation System [IEEE2005]"
   parameter Types.PerUnit V_RMAX=6.03 "Maximum exciter field output";
   parameter Types.PerUnit V_RMIN=-5.43 "Minimum exciter field output";
   NonElectrical.Logical.HV_GATE hV_GATE
-    annotation (Placement(transformation(extent={{20,46},{44,34}})));
+    annotation (Placement(transformation(extent={{20,-10},{40,10}})));
   NonElectrical.Logical.LV_GATE lV_GATE
-    annotation (Placement(transformation(extent={{58,46},{82,34}})));
+    annotation (Placement(transformation(extent={{60,-10},{80,10}})));
   NonElectrical.Continuous.LeadLag imLeadLag(
     K=1,
     T1=T_C,
     T2=T_B,
     y_start=VR0/K_A,
     x_start=VR0/K_A)
-    annotation (Placement(transformation(extent={{-52,30},{-32,50}})));
+    annotation (Placement(transformation(extent={{-50,-10},{-30,10}})));
   NonElectrical.Continuous.SimpleLag imSimpleLag(
     K=1,
     y_start=ECOMP0,
     T=T_R) annotation (Placement(transformation(extent={{-170,-10},{-150,10}})));
   Modelica.Blocks.Nonlinear.Limiter limiter1(uMax=V_RMAX, uMin=V_RMIN)
-    annotation (Placement(transformation(extent={{94,30},{114,50}})));
+    annotation (Placement(transformation(extent={{94,-10},{114,10}})));
   NonElectrical.Continuous.SimpleLagLim simpleLagLim(
     K=K_A,
     T=T_A,
     y_start=VR0,
     outMax=V_AMAX,
     outMin=V_AMIN)
-    annotation (Placement(transformation(extent={{-16,30},{4,50}})));
+    annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
   Modelica.Blocks.Continuous.Derivative derivative(
     k=K_F,
     T=T_F,
     initType=Modelica.Blocks.Types.Init.InitialOutput,
     y_start=0,
     x_start=VFE0)
-    annotation (Placement(transformation(extent={{40,-10},{20,10}})));
+    annotation (Placement(transformation(extent={{40,-50},{20,-30}})));
   BaseClasses.RotatingExciterWithDemagnetizationLimited
     rotatingExciterWithDemagnetization(
     T_E=T_E,
@@ -63,12 +63,12 @@ model ESAC1A "AC1A Excitation System [IEEE2005]"
     S_EE_1=S_EE_1,
     S_EE_2=S_EE_2,
     K_D=K_D,
-    Efd0=VE0) annotation (Placement(transformation(extent={{124,30},{144,50}})));
+    Efd0=VE0) annotation (Placement(transformation(extent={{130,-10},{150,10}})));
   Modelica.Blocks.Math.Add3 add3_1(k3=-1)
-    annotation (Placement(transformation(extent={{-88,30},{-68,50}})));
+    annotation (Placement(transformation(extent={{-86,-10},{-66,10}})));
   BaseClasses.RectifierCommutationVoltageDrop rectifierCommutationVoltageDrop(
       K_C=K_C)
-    annotation (Placement(transformation(extent={{160,30},{180,50}})));
+    annotation (Placement(transformation(extent={{160,-10},{180,10}})));
 protected
   parameter Real VR0(fixed=false);
   parameter Real Efd0(fixed=false);
@@ -91,41 +91,39 @@ initial equation
   V_REF = VR0/K_A + ECOMP0;
 equation
   connect(imLeadLag.y, simpleLagLim.u)
-    annotation (Line(points={{-31,40},{-18,40}}, color={0,0,127}));
+    annotation (Line(points={{-29,0},{-22,0}},   color={0,0,127}));
   connect(limiter1.y, rotatingExciterWithDemagnetization.I_C)
-    annotation (Line(points={{115,40},{122.75,40}}, color={0,0,127}));
+    annotation (Line(points={{115,0},{128.75,0}},   color={0,0,127}));
   connect(ECOMP, imSimpleLag.u)
     annotation (Line(points={{-200,0},{-172,0}}, color={0,0,127}));
-  connect(simpleLagLim.y,hV_GATE.u1)  annotation (Line(points={{5,40},{12,40},{
-          12,37},{18.5,37}}, color={0,0,127}));
-  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-130,-40},{14,
-          -40},{14,43},{18.5,43}}, color={0,0,127}));
-  connect(imSimpleLag.y, DiffV.u2) annotation (Line(points={{-149,0},{-132,0},{
-          -132,-6},{-122,-6}}, color={0,0,127}));
+  connect(simpleLagLim.y,hV_GATE.u1)  annotation (Line(points={{1,0},{10,0},{10,6},{18,6}},
+                             color={0,0,127}));
+  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-130,-80},{10,-80},{10,-6},{18,-6}},
+                                   color={0,0,127}));
+  connect(imSimpleLag.y, DiffV.u2) annotation (Line(points={{-149,0},{-140,0},{-140,-6},{-122,-6}},
+                               color={0,0,127}));
   connect(add3_1.y, imLeadLag.u)
-    annotation (Line(points={{-67,40},{-54,40}}, color={0,0,127}));
-  connect(DiffV.y, add3_1.u2) annotation (Line(points={{-99,0},{-96,0},{-96,40},
-          {-90,40}}, color={0,0,127}));
-  connect(VOTHSG, add3_1.u1) annotation (Line(points={{-200,90},{-150,90},{-96,
-          90},{-96,48},{-90,48}}, color={0,0,127}));
-  connect(derivative.y, add3_1.u3) annotation (Line(points={{19,0},{-94,0},{-94,
-          32},{-90,32}}, color={0,0,127}));
+    annotation (Line(points={{-65,0},{-52,0}},   color={0,0,127}));
+  connect(DiffV.y, add3_1.u2) annotation (Line(points={{-99,0},{-88,0}},
+                     color={0,0,127}));
+  connect(VOTHSG, add3_1.u1) annotation (Line(points={{-200,90},{-96,90},{-96,8},{-88,8}},
+                                  color={0,0,127}));
+  connect(derivative.y, add3_1.u3) annotation (Line(points={{19,-40},{-94,-40},{-94,-8},{-88,-8}},
+                         color={0,0,127}));
   connect(derivative.u, rotatingExciterWithDemagnetization.V_FE) annotation (
-      Line(points={{42,0},{82,0},{120,0},{120,33.75},{122.75,33.75}}, color={0,
+      Line(points={{42,-40},{120,-40},{120,-6.25},{128.75,-6.25}},    color={0,
           0,127}));
   connect(rotatingExciterWithDemagnetization.EFD,
     rectifierCommutationVoltageDrop.V_EX)
-    annotation (Line(points={{145.25,40},{159,40}}, color={0,0,127}));
-  connect(rectifierCommutationVoltageDrop.EFD, EFD) annotation (Line(points={{
-          181,40},{190,40},{190,0},{210,0}}, color={0,0,127}));
-  connect(hV_GATE.y,lV_GATE.u2)  annotation (Line(points={{42.5,40},{50,40},{50,
-          43},{56.5,43}}, color={0,0,127}));
-  connect(VOEL,lV_GATE.u1)  annotation (Line(points={{-70,-200},{-70,-200},{-70,
-          -60},{50,-60},{50,37},{56.5,37}}, color={0,0,127}));
+    annotation (Line(points={{151.25,0},{159,0}},   color={0,0,127}));
+  connect(rectifierCommutationVoltageDrop.EFD, EFD) annotation (Line(points={{181,0},{210,0}},
+                                             color={0,0,127}));
   connect(lV_GATE.y, limiter1.u)
-    annotation (Line(points={{80.5,40},{92,40}}, color={0,0,127}));
-  connect(XADIFD, rotatingExciterWithDemagnetization.XADIFD) annotation (Line(points={{80,-200},{80,-120},{134,-120},{134,28.75}}, color={0,0,127}));
-  connect(XADIFD, rectifierCommutationVoltageDrop.XADIFD) annotation (Line(points={{80,-200},{80,-120},{170,-120},{170,29}}, color={0,0,127}));
+    annotation (Line(points={{81,0},{92,0}},     color={0,0,127}));
+  connect(XADIFD, rotatingExciterWithDemagnetization.XADIFD) annotation (Line(points={{80,-200},{80,-160},{140,-160},{140,-11.25}},color={0,0,127}));
+  connect(XADIFD, rectifierCommutationVoltageDrop.XADIFD) annotation (Line(points={{80,-200},{80,-160},{170,-160},{170,-11}},color={0,0,127}));
+  connect(VOEL, lV_GATE.u2) annotation (Line(points={{-70,-200},{-70,-100},{50,-100},{50,-6},{58,-6}}, color={0,0,127}));
+  connect(lV_GATE.u1, hV_GATE.y) annotation (Line(points={{58,6},{50,6},{50,0},{41,0}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(extent={{-200,-200},{200,160}})),
     Icon(coordinateSystem(extent={{-100,-100},{100,100}}),

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESAC1A.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESAC1A.mo
@@ -96,9 +96,9 @@ equation
     annotation (Line(points={{115,40},{122.75,40}}, color={0,0,127}));
   connect(ECOMP, imSimpleLag.u)
     annotation (Line(points={{-200,0},{-172,0}}, color={0,0,127}));
-  connect(simpleLagLim.y, hV_GATE.n1) annotation (Line(points={{5,40},{12,40},{
+  connect(simpleLagLim.y,hV_GATE.u1)  annotation (Line(points={{5,40},{12,40},{
           12,37},{18.5,37}}, color={0,0,127}));
-  connect(VUEL, hV_GATE.n2) annotation (Line(points={{-130,-200},{-130,-40},{14,
+  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-130,-40},{14,
           -40},{14,43},{18.5,43}}, color={0,0,127}));
   connect(imSimpleLag.y, DiffV.u2) annotation (Line(points={{-149,0},{-132,0},{
           -132,-6},{-122,-6}}, color={0,0,127}));
@@ -118,11 +118,11 @@ equation
     annotation (Line(points={{145.25,40},{159,40}}, color={0,0,127}));
   connect(rectifierCommutationVoltageDrop.EFD, EFD) annotation (Line(points={{
           181,40},{190,40},{190,0},{210,0}}, color={0,0,127}));
-  connect(hV_GATE.p, lV_GATE.n2) annotation (Line(points={{42.5,40},{50,40},{50,
+  connect(hV_GATE.y,lV_GATE.u2)  annotation (Line(points={{42.5,40},{50,40},{50,
           43},{56.5,43}}, color={0,0,127}));
-  connect(VOEL, lV_GATE.n1) annotation (Line(points={{-70,-200},{-70,-200},{-70,
+  connect(VOEL,lV_GATE.u1)  annotation (Line(points={{-70,-200},{-70,-200},{-70,
           -60},{50,-60},{50,37},{56.5,37}}, color={0,0,127}));
-  connect(lV_GATE.p, limiter1.u)
+  connect(lV_GATE.y, limiter1.u)
     annotation (Line(points={{80.5,40},{92,40}}, color={0,0,127}));
   connect(XADIFD, rotatingExciterWithDemagnetization.XADIFD) annotation (Line(points={{80,-200},{80,-120},{134,-120},{134,28.75}}, color={0,0,127}));
   connect(XADIFD, rectifierCommutationVoltageDrop.XADIFD) annotation (Line(points={{80,-200},{80,-120},{170,-120},{170,29}}, color={0,0,127}));

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESAC2A.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESAC2A.mo
@@ -131,7 +131,7 @@ equation
     annotation (Line(points={{115,40},{122.75,40}}, color={0,0,127}));
   connect(ECOMP, imSimpleLag.u)
     annotation (Line(points={{-200,0},{-172,0}}, color={0,0,127}));
-  connect(VUEL, hV_GATE.n2) annotation (Line(points={{-130,-200},{-130,-22},{26,
+  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-130,-22},{26,
           -22},{26,43},{30.5,43}}, color={0,0,127}));
   connect(imSimpleLag.y, DiffV.u2) annotation (Line(points={{-149,0},{-132,0},{
           -132,-6},{-122,-6}}, color={0,0,127}));
@@ -156,12 +156,12 @@ equation
                                                        color={0,0,127}));
   connect(rectifierCommutationVoltageDrop.EFD, EFD) annotation (Line(points={{
           181,40},{190,40},{190,0},{210,0}}, color={0,0,127}));
-  connect(hV_GATE.p, lV_GATE.n2) annotation (Line(points={{54.5,40},{56,40},{56,
+  connect(hV_GATE.y,lV_GATE.u2)  annotation (Line(points={{54.5,40},{56,40},{56,
           42},{58,42},{58,43},{62.5,43}},
                           color={0,0,127}));
-  connect(VOEL, lV_GATE.n1) annotation (Line(points={{-70,-200},{-70,-60},{58,-60},
+  connect(VOEL,lV_GATE.u1)  annotation (Line(points={{-70,-200},{-70,-60},{58,-60},
           {58,37},{62.5,37}},               color={0,0,127}));
-  connect(lV_GATE.p, limiter1.u)
+  connect(lV_GATE.y, limiter1.u)
     annotation (Line(points={{86.5,40},{92,40}},         color={0,0,127}));
   connect(lowLim.y, rotatingExciterWithDemagnetization.outMin) annotation (Line(
         points={{159,80},{150,80},{150,47.5},{145.25,47.5}}, color={0,0,127}));
@@ -192,7 +192,7 @@ equation
           {-6,-2}}, color={0,0,127}));
   connect(DiffV3.y, gain1.u) annotation (Line(points={{17,4},{20,4},{20,24},{-14,
           24},{-14,40},{-2,40}}, color={0,0,127}));
-  connect(gain1.y, hV_GATE.n1)
+  connect(gain1.y,hV_GATE.u1)
     annotation (Line(points={{21,40},{30.5,40},{30.5,37}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(extent={{-200,-200},{200,160}})),

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESAC2A.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESAC2A.mo
@@ -27,9 +27,9 @@ import OpenIPSL.NonElectrical.Functions.SE;
   parameter Types.PerUnit S_EE_1=0.03 "Exciter saturation factor at exciter output voltage E1";
   parameter Types.PerUnit S_EE_2=0.1 "Exciter saturation factor at exciter output voltage E2";
   NonElectrical.Logical.HV_GATE hV_GATE
-    annotation (Placement(transformation(extent={{32,46},{56,34}})));
+    annotation (Placement(transformation(extent={{32,30},{52,50}})));
   NonElectrical.Logical.LV_GATE lV_GATE
-    annotation (Placement(transformation(extent={{64,46},{88,34}})));
+    annotation (Placement(transformation(extent={{64,30},{84,50}})));
   NonElectrical.Continuous.LeadLag imLeadLag(
     K=1,
     T1=T_C,
@@ -131,8 +131,8 @@ equation
     annotation (Line(points={{115,40},{122.75,40}}, color={0,0,127}));
   connect(ECOMP, imSimpleLag.u)
     annotation (Line(points={{-200,0},{-172,0}}, color={0,0,127}));
-  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-130,-22},{26,
-          -22},{26,43},{30.5,43}}, color={0,0,127}));
+  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-130,-22},{26,-22},{26,34},{30,34}},
+                                   color={0,0,127}));
   connect(imSimpleLag.y, DiffV.u2) annotation (Line(points={{-149,0},{-132,0},{
           -132,-6},{-122,-6}}, color={0,0,127}));
   connect(add3_1.y, imLeadLag.u)
@@ -156,19 +156,14 @@ equation
                                                        color={0,0,127}));
   connect(rectifierCommutationVoltageDrop.EFD, EFD) annotation (Line(points={{
           181,40},{190,40},{190,0},{210,0}}, color={0,0,127}));
-  connect(hV_GATE.y,lV_GATE.u2)  annotation (Line(points={{54.5,40},{56,40},{56,
-          42},{58,42},{58,43},{62.5,43}},
-                          color={0,0,127}));
-  connect(VOEL,lV_GATE.u1)  annotation (Line(points={{-70,-200},{-70,-60},{58,-60},
-          {58,37},{62.5,37}},               color={0,0,127}));
   connect(lV_GATE.y, limiter1.u)
-    annotation (Line(points={{86.5,40},{92,40}},         color={0,0,127}));
+    annotation (Line(points={{85,40},{92,40}},           color={0,0,127}));
   connect(lowLim.y, rotatingExciterWithDemagnetization.outMin) annotation (Line(
         points={{159,80},{150,80},{150,47.5},{145.25,47.5}}, color={0,0,127}));
   connect(FEMAX.y, DiffV1.u1) annotation (Line(points={{61,130},{68,130},{68,
           136},{78,136}}, color={0,0,127}));
   connect(DiffV1.u2, rotatingExciterWithDemagnetization.XADIFD) annotation (
-      Line(points={{78,124},{66,124},{66,-20},{134,-20},{134,28.75}},
+      Line(points={{78,124},{68,124},{68,-20},{134,-20},{134,28.75}},
                    color={0,0,127}));
   connect(se1.VE_IN, EFD) annotation (Line(points={{180.9,108},{190,108},{190,0},
           {210,0}}, color={0,0,127}));
@@ -176,8 +171,8 @@ equation
           130},{159,130}}, color={0,0,127}));
   connect(DiffV2.u2, se1.VE_OUT) annotation (Line(points={{152,112},{156,112},{
           156,108},{161.46,108}}, color={0,0,127}));
-  connect(division.u1, DiffV1.y) annotation (Line(points={{116,92},{116,92},{
-          116,128},{116,130},{101,130}}, color={0,0,127}));
+  connect(division.u1, DiffV1.y) annotation (Line(points={{116,92},{116,92},{116,128},{116,130},{101,130}},
+                                         color={0,0,127}));
   connect(DiffV2.y, division.u2)
     annotation (Line(points={{129,118},{104,118},{104,92}}, color={0,0,127}));
   connect(division.y, rotatingExciterWithDemagnetization.outMax) annotation (
@@ -193,7 +188,10 @@ equation
   connect(DiffV3.y, gain1.u) annotation (Line(points={{17,4},{20,4},{20,24},{-14,
           24},{-14,40},{-2,40}}, color={0,0,127}));
   connect(gain1.y,hV_GATE.u1)
-    annotation (Line(points={{21,40},{30.5,40},{30.5,37}}, color={0,0,127}));
+    annotation (Line(points={{21,40},{24,40},{24,46},{30,46}},
+                                                           color={0,0,127}));
+  connect(VOEL, lV_GATE.u2) annotation (Line(points={{-70,-200},{-70,-60},{58,-60},{58,34},{62,34}}, color={0,0,127}));
+  connect(hV_GATE.y, lV_GATE.u1) annotation (Line(points={{53,40},{57.5,40},{57.5,46},{62,46}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(extent={{-200,-200},{200,160}})),
     Icon(coordinateSystem(extent={{-100,-100},{100,100}}),

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESDC1A.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESDC1A.mo
@@ -86,7 +86,7 @@ initial equation
 equation
   connect(add3_1.y, imLeadLag.u)
     annotation (Line(points={{-39,0},{-36,0},{-22,0}}, color={0,0,127}));
-  connect(hV_GATE.p, simpleLagLim.u)
+  connect(hV_GATE.y, simpleLagLim.u)
     annotation (Line(points={{60.625,0},{60.625,0},{78,0}}, color={0,0,127}));
   connect(simpleLagLim.y, rotatingExciterLimited.I_C)
     annotation (Line(points={{101,0},{101,0},{118.75,0}}, color={0,0,127}));
@@ -96,9 +96,9 @@ equation
           0},{-132,-6},{-122,-6}}, color={0,0,127}));
   connect(rotatingExciterLimited.EFD, EFD)
     annotation (Line(points={{141.25,0},{210,0},{210,0}}, color={0,0,127}));
-  connect(imLeadLag.y, hV_GATE.n1) annotation (Line(points={{1,0},{32,0},{32,3},
+  connect(imLeadLag.y,hV_GATE.u1)  annotation (Line(points={{1,0},{32,0},{32,3},
           {38.625,3}}, color={0,0,127}));
-  connect(VUEL, hV_GATE.n2) annotation (Line(points={{-130,-200},{-128,-200},{-128,
+  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-128,-200},{-128,
           -80},{32,-80},{32,-3},{38.625,-3}}, color={0,0,127}));
   connect(imDerivativeLag.u, EFD) annotation (Line(points={{2,-50},{160,-50},{
           160,0},{210,0}}, color={0,0,127}));

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESDC1A.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESDC1A.mo
@@ -28,7 +28,7 @@ model ESDC1A "DC1A Excitation System [IEEE2005]"
     x_start=Efd0)
     annotation (Placement(transformation(extent={{0,-60},{-20,-40}})));
   NonElectrical.Logical.HV_GATE hV_GATE
-    annotation (Placement(transformation(extent={{40,-6},{62,6}})));
+    annotation (Placement(transformation(extent={{40,-10},{60,10}})));
   NonElectrical.Continuous.LeadLag imLeadLag(
     K=1,
     T1=T_C,
@@ -87,7 +87,7 @@ equation
   connect(add3_1.y, imLeadLag.u)
     annotation (Line(points={{-39,0},{-36,0},{-22,0}}, color={0,0,127}));
   connect(hV_GATE.y, simpleLagLim.u)
-    annotation (Line(points={{60.625,0},{60.625,0},{78,0}}, color={0,0,127}));
+    annotation (Line(points={{61,0},{78,0}},                color={0,0,127}));
   connect(simpleLagLim.y, rotatingExciterLimited.I_C)
     annotation (Line(points={{101,0},{101,0},{118.75,0}}, color={0,0,127}));
   connect(ECOMP, TransducerDelay.u)
@@ -96,10 +96,10 @@ equation
           0},{-132,-6},{-122,-6}}, color={0,0,127}));
   connect(rotatingExciterLimited.EFD, EFD)
     annotation (Line(points={{141.25,0},{210,0},{210,0}}, color={0,0,127}));
-  connect(imLeadLag.y,hV_GATE.u1)  annotation (Line(points={{1,0},{32,0},{32,3},
-          {38.625,3}}, color={0,0,127}));
-  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-128,-200},{-128,
-          -80},{32,-80},{32,-3},{38.625,-3}}, color={0,0,127}));
+  connect(imLeadLag.y,hV_GATE.u1)  annotation (Line(points={{1,0},{32,0},{32,6},{38,6}},
+                       color={0,0,127}));
+  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-128,-200},{-128,-80},{32,-80},{32,-6},{38,-6}},
+                                              color={0,0,127}));
   connect(imDerivativeLag.u, EFD) annotation (Line(points={{2,-50},{160,-50},{
           160,0},{210,0}}, color={0,0,127}));
   connect(imDerivativeLag.y, add3_1.u3) annotation (Line(points={{-21,-50},{-46,

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESDC2A.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESDC2A.mo
@@ -106,9 +106,9 @@ equation
           0},{-132,-6},{-122,-6}}, color={0,0,127}));
   connect(rotatingExciterLimited.EFD, EFD)
     annotation (Line(points={{141.25,0},{210,0},{210,0}}, color={0,0,127}));
-  connect(imLeadLag.y, hV_GATE.n1) annotation (Line(points={{1,0},{32,0},{32,3},
+  connect(imLeadLag.y,hV_GATE.u1)  annotation (Line(points={{1,0},{32,0},{32,3},
           {38.625,3}}, color={0,0,127}));
-  connect(VUEL, hV_GATE.n2) annotation (Line(points={{-130,-200},{-128,-200},{-128,
+  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-128,-200},{-128,
           -80},{32,-80},{32,-3},{38.625,-3}}, color={0,0,127}));
   connect(imDerivativeLag.u, EFD) annotation (Line(points={{2,-50},{160,-50},{
           160,0},{210,0}}, color={0,0,127}));
@@ -122,7 +122,7 @@ equation
           -60},{-96,-60},{-96,34},{-92,34}}, color={0,0,127}));
   connect(DiffV1.y, add3_1.u1) annotation (Line(points={{-69,40},{-66,40},{-66,
           8},{-62,8}}, color={0,0,127}));
-  connect(simpleLagLimVar.u, hV_GATE.p)
+  connect(simpleLagLimVar.u,hV_GATE.y)
     annotation (Line(points={{78,0},{60.625,0}}, color={0,0,127}));
   connect(simpleLagLimVar.y, rotatingExciterLimited.I_C)
     annotation (Line(points={{101,0},{118.75,0}}, color={0,0,127}));

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESDC2A.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESDC2A.mo
@@ -28,7 +28,7 @@ model ESDC2A "DC2A Excitation System [IEEE2005]"
     x_start=Efd0)
     annotation (Placement(transformation(extent={{0,-60},{-20,-40}})));
   NonElectrical.Logical.HV_GATE hV_GATE
-    annotation (Placement(transformation(extent={{40,-6},{62,6}})));
+    annotation (Placement(transformation(extent={{40,-10},{60,10}})));
   NonElectrical.Continuous.LeadLag imLeadLag(
     K=1,
     T1=T_C,
@@ -61,7 +61,7 @@ model ESDC2A "DC2A Excitation System [IEEE2005]"
   Modelica.Blocks.Interfaces.RealInput VT annotation (Placement(transformation(
         extent={{-20,-20},{20,20}},
         rotation=90,
-        origin={102,-120}), iconTransformation(
+        origin={140,-200}), iconTransformation(
         extent={{-10,-10},{10,10}},
         origin={-110,-80})));
   Modelica.Blocks.Math.Gain gain(k=V_RMIN0) annotation (Placement(
@@ -106,10 +106,10 @@ equation
           0},{-132,-6},{-122,-6}}, color={0,0,127}));
   connect(rotatingExciterLimited.EFD, EFD)
     annotation (Line(points={{141.25,0},{210,0},{210,0}}, color={0,0,127}));
-  connect(imLeadLag.y,hV_GATE.u1)  annotation (Line(points={{1,0},{32,0},{32,3},
-          {38.625,3}}, color={0,0,127}));
-  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-128,-200},{-128,
-          -80},{32,-80},{32,-3},{38.625,-3}}, color={0,0,127}));
+  connect(imLeadLag.y,hV_GATE.u1)  annotation (Line(points={{1,0},{32,0},{32,6},{38,6}},
+                       color={0,0,127}));
+  connect(VUEL,hV_GATE.u2)  annotation (Line(points={{-130,-200},{-128,-200},{-128,-80},{32,-80},{32,-6},{38,-6}},
+                                              color={0,0,127}));
   connect(imDerivativeLag.u, EFD) annotation (Line(points={{2,-50},{160,-50},{
           160,0},{210,0}}, color={0,0,127}));
   connect(imDerivativeLag.y, add3_1.u3) annotation (Line(points={{-21,-50},{-46,
@@ -123,17 +123,17 @@ equation
   connect(DiffV1.y, add3_1.u1) annotation (Line(points={{-69,40},{-66,40},{-66,
           8},{-62,8}}, color={0,0,127}));
   connect(simpleLagLimVar.u,hV_GATE.y)
-    annotation (Line(points={{78,0},{60.625,0}}, color={0,0,127}));
+    annotation (Line(points={{78,0},{61,0}},     color={0,0,127}));
   connect(simpleLagLimVar.y, rotatingExciterLimited.I_C)
     annotation (Line(points={{101,0},{118.75,0}}, color={0,0,127}));
-  connect(VT, gain.u) annotation (Line(points={{102,-120},{102,-92},{82,-92},{
-          82,-82}}, color={0,0,127}));
+  connect(VT, gain.u) annotation (Line(points={{140,-200},{140,-100},{82,-100},{82,-82}},
+                    color={0,0,127}));
   connect(gain.y, simpleLagLimVar.outMin)
     annotation (Line(points={{82,-59},{82,-36},{82,-14}}, color={0,0,127}));
   connect(gain1.y, simpleLagLimVar.outMax) annotation (Line(points={{110,-59},{
           110,-59},{110,20},{98,20},{98,14}}, color={0,0,127}));
-  connect(gain1.u, gain.u) annotation (Line(points={{110,-82},{110,-92},{82,-92},
-          {82,-82}}, color={0,0,127}));
+  connect(gain1.u, gain.u) annotation (Line(points={{110,-82},{110,-100},{82,-100},{82,-82}},
+                     color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(
         extent={{-200,-200},{200,160}},

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESST1A.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESST1A.mo
@@ -165,7 +165,7 @@ equation
     annotation (Line(points={{136,-19},{136,-8},{176,-8}}, color={0,0,127}));
   connect(add3_1.u1, imDerivativeLag.y) annotation (Line(points={{-94,8},{-98,8},
           {-98,70},{-1,70}}, color={0,0,127}));
-  connect(VUEL2, hV_GATE.n2) annotation (Line(points={{-10,-200},{-10,-174},{-42,-174},{-42,-2.625},{-38.1188,-2.625}},
+  connect(VUEL2,hV_GATE.u2)  annotation (Line(points={{-10,-200},{-10,-174},{-42,-174},{-42,-2.625},{-38.1188,-2.625}},
                                                  color={0,0,127}));
   connect(variableLimiter.y, EFD)
     annotation (Line(points={{199,0},{210,0}}, color={0,0,127}));
@@ -175,7 +175,7 @@ equation
           -50},{164,-42}}, color={0,0,127}));
   connect(VT, imGain2.u) annotation (Line(points={{150,-140},{150,-111},{150,-82}},
         color={0,0,127}));
-  connect(VOEL, lV_GATE.n2) annotation (Line(points={{-70,-200},{-70,-200},{-70,
+  connect(VOEL,lV_GATE.u2)  annotation (Line(points={{-70,-200},{-70,-200},{-70,
           -100},{100,-100},{100,-3.525},{129.225,-3.525}}, color={0,0,127}));
   connect(imGain1.u, imGain2.u) annotation (Line(points={{136,-42},{136,-120},{
           150,-120},{150,-82}}, color={0,0,127}));
@@ -191,17 +191,17 @@ equation
           90},{-140,-44},{-122,-44}}, color={0,0,127}));
   connect(Limiters.y, add3_1.u3) annotation (Line(points={{-99,-50},{-98,-50},{
           -98,-8},{-94,-8}}, color={0,0,127}));
-  connect(imLimited.y, hV_GATE.n1) annotation (Line(points={{-43,0},{-42,0},{-42,3.125},{-38.1188,3.125}},
+  connect(imLimited.y,hV_GATE.u1)  annotation (Line(points={{-43,0},{-42,0},{-42,3.125},{-38.1188,3.125}},
                                     color={0,0,127}));
   connect(VOTHSG2, add3_2.u1) annotation (Line(points={{-200,132},{70,132},{70,
           8},{76,8}}, color={0,0,127}));
-  connect(lV_GATE.p, variableLimiter.u) annotation (Line(points={{154.425,-0.35},
+  connect(lV_GATE.y, variableLimiter.u) annotation (Line(points={{154.425,-0.35},
           {164.213,-0.35},{164.213,0},{176,0}}, color={0,0,127}));
-  connect(hV_GATE1.p, lV_GATE.n1) annotation (Line(points={{124.706,2.65},{124.228,2.65},{124.228,2.825},{129.225,2.825}},
+  connect(hV_GATE1.y,lV_GATE.u1)  annotation (Line(points={{124.706,2.65},{124.228,2.65},{124.228,2.825},{129.225,2.825}},
                                                           color={0,0,127}));
-  connect(add3_2.y, hV_GATE1.n1) annotation (Line(points={{99,0},{100,0},{100,5.325},{104.006,5.325}},
+  connect(add3_2.y,hV_GATE1.u1)  annotation (Line(points={{99,0},{100,0},{100,5.325},{104.006,5.325}},
                                    color={0,0,127}));
-  connect(imDerivativeLag.u, hV_GATE1.n1) annotation (Line(points={{22,70},{102,70},{102,5.325},{104.006,5.325}},
+  connect(imDerivativeLag.u,hV_GATE1.u1)  annotation (Line(points={{22,70},{102,70},{102,5.325},{104.006,5.325}},
                                             color={0,0,127}));
   connect(imGain.u, add2.y)
     annotation (Line(points={{40,-82},{40,-109},{40,-109}}, color={0,0,127}));
@@ -213,9 +213,9 @@ equation
     annotation (Line(points={{170,-19},{170,8},{176,8}}, color={0,0,127}));
   connect(simpleLagLim.y, add3_2.u2)
     annotation (Line(points={{71,0},{76,0}}, color={0,0,127}));
-  connect(hV_GATE.p, imLeadLag.u) annotation (Line(points={{-15.4187,0.25},{-12.7094,0.25},{-12.7094,0},{-10,0}},
+  connect(hV_GATE.y, imLeadLag.u) annotation (Line(points={{-15.4187,0.25},{-12.7094,0.25},{-12.7094,0},{-10,0}},
                                        color={0,0,127}));
-  connect(VUEL3, hV_GATE1.n2) annotation (Line(points={{50,-200},{50,-200},{50,-174},{110,-174},{110,-20},{104.006,-20},{104.006,-0.025}},
+  connect(VUEL3,hV_GATE1.u2)  annotation (Line(points={{50,-200},{50,-200},{50,-174},{110,-174},{110,-20},{104.006,-20},{104.006,-0.025}},
                                                                       color={0,
           0,127}));
   connect(XADIFD, add2.u2) annotation (Line(points={{80,-200},{80,-160},{46,-160},{46,-132}}, color={0,0,127}));

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESST1A.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESST1A.mo
@@ -58,7 +58,7 @@ model ESST1A "ST1A Excitation System [IEEE2005]"
   Modelica.Blocks.Nonlinear.Limiter imLimited(uMin=V_IMIN, uMax=V_IMAX)
     annotation (Placement(transformation(extent={{-64,-10},{-44,10}})));
   NonElectrical.Logical.HV_GATE hV_GATE
-    annotation (Placement(transformation(extent={{-36.7,-5.5},{-14,6}})));
+    annotation (Placement(transformation(extent={{-36,-10},{-16,10}})));
   Modelica.Blocks.Interfaces.RealInput VUEL2 "UEL=2" annotation (Placement(
         transformation(
         extent={{-20,-20},{20,20}},
@@ -72,14 +72,14 @@ model ESST1A "ST1A Excitation System [IEEE2005]"
         rotation=90,
         origin={40,-70})));
   NonElectrical.Logical.HV_GATE hV_GATE1
-    annotation (Placement(transformation(extent={{105.3,-2.7},{126,8}})));
+    annotation (Placement(transformation(extent={{110,-10},{130,10}})));
   NonElectrical.Logical.LV_GATE lV_GATE
-    annotation (Placement(transformation(extent={{130.8,-6.7},{156,6}})));
+    annotation (Placement(transformation(extent={{140,-10},{160,10}})));
   Modelica.Blocks.Interfaces.RealInput VT "sensed VT" annotation (Placement(
         transformation(
-        extent={{10,-10},{-10,10}},
+        extent={{20,-20},{-20,20}},
         rotation=270,
-        origin={150,-140}), iconTransformation(
+        origin={130,-200}), iconTransformation(
         extent={{-9.75,-10.25},{9.75,10.25}},
         origin={-109.75,-78.25})));
   Modelica.Blocks.Sources.Constant Vref1(k=I_LR)
@@ -97,7 +97,7 @@ model ESST1A "ST1A Excitation System [IEEE2005]"
     T1=T_C1,
     T2=T_B1,
     x_start=VA0/K_A)
-    annotation (Placement(transformation(extent={{22,-9},{42,10}})));
+    annotation (Placement(transformation(extent={{20,-10},{40,10}})));
   Modelica.Blocks.Math.Add3 add3_1(k1=-1)
     annotation (Placement(transformation(extent={{-92,-10},{-72,10}})));
   NonElectrical.Continuous.SimpleLagLim simpleLagLim(
@@ -106,7 +106,7 @@ model ESST1A "ST1A Excitation System [IEEE2005]"
     y_start=VA0,
     outMax=V_AMAX,
     outMin=V_AMIN)
-    annotation (Placement(transformation(extent={{50,-10},{70,10}})));
+    annotation (Placement(transformation(extent={{48,-10},{68,10}})));
   Modelica.Blocks.Math.Add add2(k1=-1) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
@@ -122,12 +122,12 @@ model ESST1A "ST1A Excitation System [IEEE2005]"
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
-        origin={136,-30})));
+        origin={130,-50})));
   Modelica.Blocks.Math.Gain imGain2(k=V_RMAX) annotation (Placement(
         transformation(
         extent={{-10,-10},{10,10}},
         rotation=90,
-        origin={150,-70})));
+        origin={156,-70})));
   Modelica.Blocks.Math.Add add3(k1=-1) annotation (Placement(transformation(
         extent={{10,-10},{-10,10}},
         rotation=270,
@@ -137,7 +137,7 @@ model ESST1A "ST1A Excitation System [IEEE2005]"
         rotation=90,
         origin={190,-70})));
   Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter
-    annotation (Placement(transformation(extent={{178,-10},{198,10}})));
+    annotation (Placement(transformation(extent={{176,-10},{196,10}})));
   NonElectrical.Continuous.SimpleLag TransducerDelay(
     K=1,
     T=T_R,
@@ -156,29 +156,30 @@ equation
   connect(add3_1.y, imLimited.u)
     annotation (Line(points={{-71,0},{-66,0}}, color={0,0,127}));
   connect(imLeadLag.y, imLeadLag1.u)
-    annotation (Line(points={{13,0},{13,0.5},{20,0.5}}, color={0,0,127}));
+    annotation (Line(points={{13,0},{18,0}},            color={0,0,127}));
   connect(simpleLagLim.u, imLeadLag1.y)
-    annotation (Line(points={{48,0},{43,0},{43,0.5}}, color={0,0,127}));
+    annotation (Line(points={{46,0},{41,0}},          color={0,0,127}));
   connect(Vref1.y, add2.u1)
     annotation (Line(points={{21,-140},{34,-140},{34,-132}}, color={0,0,127}));
   connect(imGain1.y, variableLimiter.limit2)
-    annotation (Line(points={{136,-19},{136,-8},{176,-8}}, color={0,0,127}));
+    annotation (Line(points={{130,-39},{130,-18},{164,-18},{164,-8},{174,-8}},
+                                                           color={0,0,127}));
   connect(add3_1.u1, imDerivativeLag.y) annotation (Line(points={{-94,8},{-98,8},
           {-98,70},{-1,70}}, color={0,0,127}));
-  connect(VUEL2,hV_GATE.u2)  annotation (Line(points={{-10,-200},{-10,-174},{-42,-174},{-42,-2.625},{-38.1188,-2.625}},
+  connect(VUEL2,hV_GATE.u2)  annotation (Line(points={{-10,-200},{-10,-174},{-42,-174},{-42,-6},{-38,-6}},
                                                  color={0,0,127}));
   connect(variableLimiter.y, EFD)
-    annotation (Line(points={{199,0},{210,0}}, color={0,0,127}));
+    annotation (Line(points={{197,0},{210,0}}, color={0,0,127}));
   connect(imGain3.y, add3.u1) annotation (Line(points={{190,-59},{190,-50},{176,
           -50},{176,-42}}, color={0,0,127}));
-  connect(imGain2.y, add3.u2) annotation (Line(points={{150,-59},{150,-50},{164,
-          -50},{164,-42}}, color={0,0,127}));
-  connect(VT, imGain2.u) annotation (Line(points={{150,-140},{150,-111},{150,-82}},
+  connect(imGain2.y, add3.u2) annotation (Line(points={{156,-59},{156,-50},{164,-50},{164,-42}},
+                           color={0,0,127}));
+  connect(VT, imGain2.u) annotation (Line(points={{130,-200},{130,-120},{156,-120},{156,-82}},
         color={0,0,127}));
-  connect(VOEL,lV_GATE.u2)  annotation (Line(points={{-70,-200},{-70,-200},{-70,
-          -100},{100,-100},{100,-3.525},{129.225,-3.525}}, color={0,0,127}));
-  connect(imGain1.u, imGain2.u) annotation (Line(points={{136,-42},{136,-120},{
-          150,-120},{150,-82}}, color={0,0,127}));
+  connect(VOEL,lV_GATE.u2)  annotation (Line(points={{-70,-200},{-70,-100},{110,-100},{110,-16},{132,-16},{132,-6},{138,-6}},
+                                                           color={0,0,127}));
+  connect(imGain1.u, imGain2.u) annotation (Line(points={{130,-62},{130,-120},{156,-120},{156,-82}},
+                                color={0,0,127}));
   connect(ECOMP, TransducerDelay.u)
     annotation (Line(points={{-200,0},{-172,0}}, color={0,0,127}));
   connect(TransducerDelay.y, DiffV.u2) annotation (Line(points={{-149,0},{-132,
@@ -191,35 +192,33 @@ equation
           90},{-140,-44},{-122,-44}}, color={0,0,127}));
   connect(Limiters.y, add3_1.u3) annotation (Line(points={{-99,-50},{-98,-50},{
           -98,-8},{-94,-8}}, color={0,0,127}));
-  connect(imLimited.y,hV_GATE.u1)  annotation (Line(points={{-43,0},{-42,0},{-42,3.125},{-38.1188,3.125}},
+  connect(imLimited.y,hV_GATE.u1)  annotation (Line(points={{-43,0},{-42,0},{-42,6},{-38,6}},
                                     color={0,0,127}));
-  connect(VOTHSG2, add3_2.u1) annotation (Line(points={{-200,132},{70,132},{70,
-          8},{76,8}}, color={0,0,127}));
-  connect(lV_GATE.y, variableLimiter.u) annotation (Line(points={{154.425,-0.35},
-          {164.213,-0.35},{164.213,0},{176,0}}, color={0,0,127}));
-  connect(hV_GATE1.y,lV_GATE.u1)  annotation (Line(points={{124.706,2.65},{124.228,2.65},{124.228,2.825},{129.225,2.825}},
+  connect(VOTHSG2, add3_2.u1) annotation (Line(points={{-200,132},{70,132},{70,8},{76,8}},
+                      color={0,0,127}));
+  connect(lV_GATE.y, variableLimiter.u) annotation (Line(points={{161,0},{174,0}},
+                                                color={0,0,127}));
+  connect(hV_GATE1.y,lV_GATE.u1)  annotation (Line(points={{131,0},{134,0},{134,6},{138,6}},
                                                           color={0,0,127}));
-  connect(add3_2.y,hV_GATE1.u1)  annotation (Line(points={{99,0},{100,0},{100,5.325},{104.006,5.325}},
-                                   color={0,0,127}));
-  connect(imDerivativeLag.u,hV_GATE1.u1)  annotation (Line(points={{22,70},{102,70},{102,5.325},{104.006,5.325}},
-                                            color={0,0,127}));
   connect(imGain.u, add2.y)
     annotation (Line(points={{40,-82},{40,-109},{40,-109}}, color={0,0,127}));
   connect(imLimited1.u, imGain.y)
     annotation (Line(points={{40.4,-52},{40,-52},{40,-59}}, color={0,0,127}));
-  connect(imLimited1.y, add3_2.u3) annotation (Line(points={{40.4,-29},{40.4,-20},
-          {70,-20},{70,-8},{76,-8}}, color={0,0,127}));
+  connect(imLimited1.y, add3_2.u3) annotation (Line(points={{40.4,-29},{40.4,-20},{70,-20},{70,-8},{76,-8}},
+                                     color={0,0,127}));
   connect(add3.y, variableLimiter.limit1)
-    annotation (Line(points={{170,-19},{170,8},{176,8}}, color={0,0,127}));
+    annotation (Line(points={{170,-19},{170,8},{174,8}}, color={0,0,127}));
   connect(simpleLagLim.y, add3_2.u2)
-    annotation (Line(points={{71,0},{76,0}}, color={0,0,127}));
-  connect(hV_GATE.y, imLeadLag.u) annotation (Line(points={{-15.4187,0.25},{-12.7094,0.25},{-12.7094,0},{-10,0}},
+    annotation (Line(points={{69,0},{76,0}}, color={0,0,127}));
+  connect(hV_GATE.y, imLeadLag.u) annotation (Line(points={{-15,0},{-10,0}},
                                        color={0,0,127}));
-  connect(VUEL3,hV_GATE1.u2)  annotation (Line(points={{50,-200},{50,-200},{50,-174},{110,-174},{110,-20},{104.006,-20},{104.006,-0.025}},
+  connect(VUEL3,hV_GATE1.u2)  annotation (Line(points={{50,-200},{50,-170},{100,-170},{100,-6},{108,-6}},
                                                                       color={0,
           0,127}));
   connect(XADIFD, add2.u2) annotation (Line(points={{80,-200},{80,-160},{46,-160},{46,-132}}, color={0,0,127}));
   connect(XADIFD, imGain3.u) annotation (Line(points={{80,-200},{80,-160},{190,-160},{190,-82}}, color={0,0,127}));
+  connect(add3_2.y, hV_GATE1.u1) annotation (Line(points={{99,0},{102,0},{102,6},{108,6}}, color={0,0,127}));
+  connect(imDerivativeLag.u, add3_2.y) annotation (Line(points={{22,70},{102,70},{102,0},{99,0}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(
         extent={{-200,-200},{200,160}},

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESST4B.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESST4B.mo
@@ -122,7 +122,7 @@ equation
       points={{121,-110},{148,-110},{148,-76},{158,-76}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(lV_Gate.p, product.u1) annotation (Line(
+  connect(lV_Gate.y, product.u1) annotation (Line(
       points={{142.5,-64},{158,-64}},
       color={0,0,127},
       smooth=Smooth.None));
@@ -160,9 +160,9 @@ equation
     annotation (Line(points={{161,0},{164.5,0},{168,0}}, color={0,0,127}));
   connect(product.y, EFD) annotation (Line(points={{181,-70},{198,-70},{198,0},
           {210,0}}, color={0,0,127}));
-  connect(lV_Gate.n2, VOEL) annotation (Line(points={{118.5,-67},{0,-67},{0,-160},
+  connect(lV_Gate.u2, VOEL) annotation (Line(points={{118.5,-67},{0,-67},{0,-160},
           {-70,-160},{-70,-200}}, color={0,0,127}));
-  connect(limiter1.y, lV_Gate.n1) annotation (Line(points={{191,0},{194,0},{194,
+  connect(limiter1.y,lV_Gate.u1)  annotation (Line(points={{191,0},{194,0},{194,
           -50},{112,-50},{112,-61},{118.5,-61}}, color={0,0,127}));
   connect(gain.u, EFD) annotation (Line(points={{132,60},{198,60},{198,0},{210,
           0}}, color={0,0,127}));

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ESST4B.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ESST4B.mo
@@ -22,7 +22,7 @@ model ESST4B "ST4B Excitation System [IEEE2005]"
   parameter Types.PerUnit X_L=0 "Reactance associated with potential source";
   parameter Types.Angle THETAP=0 "Potential circuit phase angle";
   NonElectrical.Logical.LV_GATE lV_Gate
-    annotation (Placement(transformation(extent={{120,-70},{144,-58}})));
+    annotation (Placement(transformation(extent={{120,-74},{140,-54}})));
   Modelica.Blocks.Math.Product product
     annotation (Placement(transformation(extent={{160,-80},{180,-60}})));
   NonElectrical.Continuous.SimpleLag VA(
@@ -30,39 +30,39 @@ model ESST4B "ST4B Excitation System [IEEE2005]"
     T=T_A,
     y_start=VR0) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
-        origin={60,0})));
+        origin={52,0})));
   Modelica.Blocks.Continuous.LimIntegrator VR1(
     outMax=V_RMAX/K_PR,
     outMin=V_RMIN/K_PR,
     k=K_IR,
     initType=Modelica.Blocks.Types.Init.InitialOutput,
     y_start=VR0)
-    annotation (Placement(transformation(extent={{-40,-30},{-20,-10}})));
+    annotation (Placement(transformation(extent={{-48,-30},{-28,-10}})));
   Modelica.Blocks.Math.Gain Gain1(k=K_PR)
-    annotation (Placement(transformation(extent={{-40,10},{-20,30}})));
+    annotation (Placement(transformation(extent={{-48,10},{-28,30}})));
   Modelica.Blocks.Nonlinear.Limiter limiter(uMax=V_RMAX, uMin=V_RMIN)
-    annotation (Placement(transformation(extent={{20,-10},{40,10}})));
+    annotation (Placement(transformation(extent={{12,-10},{32,10}})));
   Modelica.Blocks.Math.Add add
-    annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+    annotation (Placement(transformation(extent={{-18,-10},{2,10}})));
   Modelica.Blocks.Math.Add add1(k1=-1)
-    annotation (Placement(transformation(extent={{80,-10},{100,10}})));
+    annotation (Placement(transformation(extent={{72,-10},{92,10}})));
   Modelica.Blocks.Math.Gain gain(k=K_G) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
         rotation=180,
-        origin={120,60})));
+        origin={112,60})));
   Modelica.Blocks.Continuous.LimIntegrator VM1(
     outMax=V_MMAX/K_PM,
     outMin=V_MMIN/K_PM,
     k=K_IM,
     initType=Modelica.Blocks.Types.Init.InitialOutput,
     y_start=VA0)
-    annotation (Placement(transformation(extent={{110,-30},{130,-10}})));
+    annotation (Placement(transformation(extent={{102,-30},{122,-10}})));
   Modelica.Blocks.Math.Gain Gain2(k=K_PM)
-    annotation (Placement(transformation(extent={{110,10},{130,30}})));
+    annotation (Placement(transformation(extent={{102,10},{122,30}})));
   Modelica.Blocks.Nonlinear.Limiter limiter1(uMax=V_MMAX, uMin=V_MMIN)
-    annotation (Placement(transformation(extent={{170,-10},{190,10}})));
+    annotation (Placement(transformation(extent={{162,-10},{182,10}})));
   Modelica.Blocks.Math.Add add2
-    annotation (Placement(transformation(extent={{140,-10},{160,10}})));
+    annotation (Placement(transformation(extent={{132,-10},{152,10}})));
   Modelica.Blocks.Nonlinear.Limiter maxLimiter(uMin=-Modelica.Constants.inf,
       uMax=V_BMAX)
     annotation (Placement(transformation(extent={{100,-120},{120,-100}})));
@@ -71,7 +71,7 @@ model ESST4B "ST4B Excitation System [IEEE2005]"
   OpenIPSL.Interfaces.PwPin Bus annotation (Placement(transformation(extent={{180,120},{200,140}}),
                                   iconTransformation(extent={{80,70},{100,90}})));
   Modelica.Blocks.Math.Add3 add3_1
-    annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
+    annotation (Placement(transformation(extent={{-86,-10},{-66,10}})));
   NonElectrical.Continuous.SimpleLag TransducerDelay(
     K=1,
     T=T_R,
@@ -115,7 +115,7 @@ equation
   V_T = Gen_terminal.vr + j*Gen_terminal.vi;
   I_T = Gen_terminal.ir + j*Gen_terminal.ii;
   connect(add.y, limiter.u) annotation (Line(
-      points={{11,0},{18,0}},
+      points={{3,0},{10,0}},
       color={0,0,127},
       smooth=Smooth.None));
   connect(maxLimiter.y, product.u2) annotation (Line(
@@ -123,51 +123,51 @@ equation
       color={0,0,127},
       smooth=Smooth.None));
   connect(lV_Gate.y, product.u1) annotation (Line(
-      points={{142.5,-64},{158,-64}},
+      points={{141,-64},{158,-64}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(add3_1.y, Gain1.u) annotation (Line(points={{-59,0},{-52,0},{-52,20},
-          {-42,20}}, color={0,0,127}));
-  connect(VR1.u, Gain1.u) annotation (Line(points={{-42,-20},{-52,-20},{-52,20},
-          {-42,20}}, color={0,0,127}));
+  connect(add3_1.y, Gain1.u) annotation (Line(points={{-65,0},{-60,0},{-60,20},{-50,20}},
+                     color={0,0,127}));
+  connect(VR1.u, Gain1.u) annotation (Line(points={{-50,-20},{-60,-20},{-60,20},{-50,20}},
+                     color={0,0,127}));
   connect(ECOMP, TransducerDelay.u)
     annotation (Line(points={{-200,0},{-172,0},{-172,0}}, color={0,0,127}));
   connect(TransducerDelay.y, DiffV.u2) annotation (Line(points={{-149,0},{-132,
           0},{-132,-6},{-122,-6}}, color={0,0,127}));
   connect(DiffV.y, add3_1.u2)
-    annotation (Line(points={{-99,0},{-82,0},{-82,0}}, color={0,0,127}));
-  connect(VOTHSG, add3_1.u1) annotation (Line(points={{-200,90},{-92,90},{-92,8},
-          {-82,8}}, color={0,0,127}));
-  connect(VUEL, add3_1.u3) annotation (Line(points={{-130,-200},{-130,-20},{-92,
-          -20},{-92,-8},{-82,-8}}, color={0,0,127}));
-  connect(VR1.y, add.u2) annotation (Line(points={{-19,-20},{-16,-20},{-16,-6},
-          {-12,-6}}, color={0,0,127}));
-  connect(Gain1.y, add.u1) annotation (Line(points={{-19,20},{-16,20},{-16,6},{
-          -12,6}}, color={0,0,127}));
+    annotation (Line(points={{-99,0},{-88,0}},         color={0,0,127}));
+  connect(VOTHSG, add3_1.u1) annotation (Line(points={{-200,90},{-94,90},{-94,8},{-88,8}},
+                    color={0,0,127}));
+  connect(VUEL, add3_1.u3) annotation (Line(points={{-130,-200},{-130,-20},{-94,-20},{-94,-8},{-88,-8}},
+                                   color={0,0,127}));
+  connect(VR1.y, add.u2) annotation (Line(points={{-27,-20},{-24,-20},{-24,-6},{-20,-6}},
+                     color={0,0,127}));
+  connect(Gain1.y, add.u1) annotation (Line(points={{-27,20},{-24,20},{-24,6},{-20,6}},
+                   color={0,0,127}));
   connect(limiter.y, VA.u)
-    annotation (Line(points={{41,0},{44.5,0},{48,0}}, color={0,0,127}));
+    annotation (Line(points={{33,0},{40,0}},          color={0,0,127}));
   connect(VA.y, add1.u2)
-    annotation (Line(points={{71,0},{74,0},{74,-6},{78,-6}}, color={0,0,127}));
-  connect(add1.y, Gain2.u) annotation (Line(points={{101,0},{104,0},{104,20},{
-          108,20}}, color={0,0,127}));
-  connect(VM1.u, Gain2.u) annotation (Line(points={{108,-20},{104,-20},{104,20},
-          {108,20}}, color={0,0,127}));
-  connect(Gain2.y, add2.u1) annotation (Line(points={{131,20},{134,20},{134,6},
-          {138,6}}, color={0,0,127}));
-  connect(VM1.y, add2.u2) annotation (Line(points={{131,-20},{134,-20},{134,-6},
-          {138,-6}}, color={0,0,127}));
+    annotation (Line(points={{63,0},{66,0},{66,-6},{70,-6}}, color={0,0,127}));
+  connect(add1.y, Gain2.u) annotation (Line(points={{93,0},{96,0},{96,20},{100,20}},
+                    color={0,0,127}));
+  connect(VM1.u, Gain2.u) annotation (Line(points={{100,-20},{96,-20},{96,20},{100,20}},
+                     color={0,0,127}));
+  connect(Gain2.y, add2.u1) annotation (Line(points={{123,20},{126,20},{126,6},{130,6}},
+                    color={0,0,127}));
+  connect(VM1.y, add2.u2) annotation (Line(points={{123,-20},{126,-20},{126,-6},{130,-6}},
+                     color={0,0,127}));
   connect(add2.y, limiter1.u)
-    annotation (Line(points={{161,0},{164.5,0},{168,0}}, color={0,0,127}));
-  connect(product.y, EFD) annotation (Line(points={{181,-70},{198,-70},{198,0},
-          {210,0}}, color={0,0,127}));
-  connect(lV_Gate.u2, VOEL) annotation (Line(points={{118.5,-67},{0,-67},{0,-160},
-          {-70,-160},{-70,-200}}, color={0,0,127}));
-  connect(limiter1.y,lV_Gate.u1)  annotation (Line(points={{191,0},{194,0},{194,
-          -50},{112,-50},{112,-61},{118.5,-61}}, color={0,0,127}));
-  connect(gain.u, EFD) annotation (Line(points={{132,60},{198,60},{198,0},{210,
-          0}}, color={0,0,127}));
-  connect(gain.y, add1.u1) annotation (Line(points={{109,60},{74,60},{74,6},{78,
-          6}}, color={0,0,127}));
+    annotation (Line(points={{153,0},{160,0}},           color={0,0,127}));
+  connect(product.y, EFD) annotation (Line(points={{181,-70},{196,-70},{196,0},{210,0}},
+                    color={0,0,127}));
+  connect(lV_Gate.u2, VOEL) annotation (Line(points={{118,-70},{0,-70},{0,-160},{-70,-160},{-70,-200}},
+                                  color={0,0,127}));
+  connect(limiter1.y,lV_Gate.u1)  annotation (Line(points={{183,0},{188,0},{188,-40},{112,-40},{112,-58},{118,-58}},
+                                                 color={0,0,127}));
+  connect(gain.u, EFD) annotation (Line(points={{124,60},{196,60},{196,0},{210,0}},
+               color={0,0,127}));
+  connect(gain.y, add1.u1) annotation (Line(points={{101,60},{66,60},{66,6},{70,6}},
+               color={0,0,127}));
   connect(rectifierCommutationVoltageDrop.EFD, maxLimiter.u)
     annotation (Line(points={{61,-110},{98,-110}}, color={0,0,127}));
   connect(VE, rectifierCommutationVoltageDrop.V_EX)

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/EXAC2.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/EXAC2.mo
@@ -169,11 +169,11 @@ equation
           {102,-24}}, color={0,0,127}));
   connect(gain1.y, limiter.u)
     annotation (Line(points={{92.8,0},{94,0},{98,0}}, color={0,0,127}));
-  connect(lV_GATE.p, gain1.u)
+  connect(lV_GATE.y, gain1.u)
     annotation (Line(points={{66.625,0},{74.4,0}}, color={0,0,127}));
-  connect(gain3.y, lV_GATE.n2) annotation (Line(points={{51,-30},{44.625,-30},{
+  connect(gain3.y,lV_GATE.u2)  annotation (Line(points={{51,-30},{44.625,-30},{
           44.625,-3}}, color={0,0,127}));
-  connect(DiffV1.y, lV_GATE.n1)
+  connect(DiffV1.y,lV_GATE.u1)
     annotation (Line(points={{41,0},{44.625,0},{44.625,3}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(extent={{-200,-200},{200,160}})),

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/EXAC2.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/EXAC2.mo
@@ -78,7 +78,7 @@ model EXAC2 "AC2 Excitation System [IEEE1981]"
   Modelica.Blocks.Math.Gain gain(k=K_H)
     annotation (Placement(transformation(extent={{60,-80},{40,-60}})));
   OpenIPSL.NonElectrical.Logical.LV_GATE lV_GATE
-    annotation (Placement(transformation(extent={{46,-6},{68,6}})));
+    annotation (Placement(transformation(extent={{50,-10},{70,10}})));
   Modelica.Blocks.Math.Gain gain1(k=K_B)
     annotation (Placement(transformation(extent={{76,-8},{92,8}})));
   Modelica.Blocks.Nonlinear.Limiter limiter(uMax=V_RMAX, uMin=V_RMIN)
@@ -152,7 +152,8 @@ equation
   connect(imDerivativeLag.y, add3_1.u3) annotation (Line(points={{-1,-90},{-1,-90},
           {-86,-90},{-86,-8},{-82,-8}}, color={0,0,127}));
   connect(imLimitedSimpleLag.y, DiffV1.u1)
-    annotation (Line(points={{1,0},{18,0},{18,6}}, color={0,0,127}));
+    annotation (Line(points={{1,0},{10,0},{10,6},{18,6}},
+                                                   color={0,0,127}));
   connect(gain.y, DiffV1.u2) annotation (Line(points={{39,-70},{10,-70},{10,-6},
           {18,-6}}, color={0,0,127}));
   connect(gain.u, rotatingExciterWithDemagnetizationLimited.V_FE) annotation (
@@ -170,11 +171,11 @@ equation
   connect(gain1.y, limiter.u)
     annotation (Line(points={{92.8,0},{94,0},{98,0}}, color={0,0,127}));
   connect(lV_GATE.y, gain1.u)
-    annotation (Line(points={{66.625,0},{74.4,0}}, color={0,0,127}));
-  connect(gain3.y,lV_GATE.u2)  annotation (Line(points={{51,-30},{44.625,-30},{
-          44.625,-3}}, color={0,0,127}));
+    annotation (Line(points={{71,0},{74.4,0}},     color={0,0,127}));
+  connect(gain3.y,lV_GATE.u2)  annotation (Line(points={{51,-30},{44,-30},{44,-6},{48,-6}},
+                       color={0,0,127}));
   connect(DiffV1.y,lV_GATE.u1)
-    annotation (Line(points={{41,0},{44.625,0},{44.625,3}}, color={0,0,127}));
+    annotation (Line(points={{41,0},{44,0},{44,6},{48,6}},  color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(extent={{-200,-200},{200,160}})),
     Icon(coordinateSystem(extent={{-100,-100},{100,100}}),

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ST5B.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ST5B.mo
@@ -20,12 +20,12 @@ model ST5B "ST5B Excitation System [IEEE2005]"
   parameter Types.Time T_OC2=1 "OEL regulator numerator (lead) time constant (second block)";
   parameter Types.Time T_OB2=1 "OEL regulator denominator (lag) time constant (second block)";
   Modelica.Blocks.Math.Add VERR1 annotation (Placement(transformation(
-        extent={{-10,10},{10,-10}},
+        extent={{-10,-10},{10,10}},
         origin={-10,0})));
   NonElectrical.Logical.LV_GATE lV_Gate
-    annotation (Placement(transformation(extent={{-48,0},{-26,12}})));
+    annotation (Placement(transformation(extent={{-52,-10},{-32,10}})));
   NonElectrical.Logical.HV_GATE hV_Gate
-    annotation (Placement(transformation(extent={{-84,-4},{-58,10}})));
+    annotation (Placement(transformation(extent={{-86,-10},{-66,10}})));
   NonElectrical.Continuous.LeadLagLim imLimitedLeadLag(
     K=1,
     outMax=V_RMAX/K_R,
@@ -119,11 +119,8 @@ equation
   connect(K_c.y, VERR2.u1) annotation (Line(points={{130,-81},{130,-81},{130,-6},{138,-6}}, color={0,0,127}));
   connect(imLimitedLeadLag4.y, imLimitedLeadLag5.u) annotation (Line(points={{41,-90},{41,-90},{48,-90}}, color={0,0,127}));
   connect(imLimitedLeadLag2.y, K_r.u) annotation (Line(points={{71,0},{78,0},{78,0.5}}, color={0,0,127}));
-  connect(lV_Gate.y, VERR1.u2) annotation (Line(points={{-27.375,6},{-22,6}}, color={0,0,127}));
-  connect(hV_Gate.y,lV_Gate.u2)  annotation (Line(points={{-59.625,3},{-54.8125,3},{-54.8125,3},{-49.375,3}}, color={0,0,127}));
-  connect(hV_Gate.u2, DiffV.y) annotation (Line(points={{-85.625,-0.5},{-91.8125,-0.5},{-91.8125,0},{-99,0}}, color={0,0,127}));
-  connect(hV_Gate.u1, VUEL) annotation (Line(points={{-85.625,6.5},{-92,6.5},{-92,-160},{-130,-160},{-130,-200}}, color={0,0,127}));
-  connect(lV_Gate.u1, VOEL) annotation (Line(points={{-49.375,9},{-54,9},{-54,-160},{-70,-160},{-70,-200}}, color={0,0,127}));
+  connect(lV_Gate.y, VERR1.u2) annotation (Line(points={{-31,0},{-28,0},{-28,-6},{-22,-6}},
+                                                                              color={0,0,127}));
   connect(K_r.y, limiter.u) annotation (Line(points={{101,0.5},{104.5,0.5},{104.5,0},{106,0}}, color={0,0,127}));
   connect(limiter.y, VERR2.u2) annotation (Line(points={{129,0},{132,0},{132,6},{138,6}}, color={0,0,127}));
   connect(simpleLagLimVar.y, EFD) annotation (Line(points={{195,0},{210,0},{210,0}}, color={0,0,127}));
@@ -131,9 +128,13 @@ equation
   connect(TransducerDelay.y, DiffV.u2) annotation (Line(points={{-149,0},{-132,0},{-132,-6},{-122,-6}}, color={0,0,127}));
   connect(high.u, TransducerDelay.u) annotation (Line(points={{94,-30},{-178,-30},{-178,0},{-172,0}}, color={0,0,127}));
   connect(low.u, TransducerDelay.u) annotation (Line(points={{92,-70},{80,-70},{80,-30},{-178,-30},{-178,0},{-172,0}}, color={0,0,127}));
-  connect(VOTHSG, VERR1.u1) annotation (Line(points={{-200,90},{-26,90},{-26,-6},{-22,-6}}, color={0,0,127}));
+  connect(VOTHSG, VERR1.u1) annotation (Line(points={{-200,90},{-28,90},{-28,6},{-22,6}},   color={0,0,127}));
   connect(XADIFD, K_c.u) annotation (Line(points={{80,-200},{80,-200},{80,-124},
           {80,-120},{130,-120},{130,-104}}, color={0,0,127}));
+  connect(hV_Gate.y, lV_Gate.u1) annotation (Line(points={{-65,0},{-60,0},{-60,6},{-54,6}}, color={0,0,127}));
+  connect(lV_Gate.u2, VOEL) annotation (Line(points={{-54,-6},{-60,-6},{-60,-100},{-70,-100},{-70,-200}}, color={0,0,127}));
+  connect(hV_Gate.u2, VUEL) annotation (Line(points={{-88,-6},{-94,-6},{-94,-100},{-130,-100},{-130,-200}}, color={0,0,127}));
+  connect(DiffV.y, hV_Gate.u1) annotation (Line(points={{-99,0},{-94,0},{-94,6},{-88,6}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(
         preserveAspectRatio=true,

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/ST5B.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/ST5B.mo
@@ -119,11 +119,11 @@ equation
   connect(K_c.y, VERR2.u1) annotation (Line(points={{130,-81},{130,-81},{130,-6},{138,-6}}, color={0,0,127}));
   connect(imLimitedLeadLag4.y, imLimitedLeadLag5.u) annotation (Line(points={{41,-90},{41,-90},{48,-90}}, color={0,0,127}));
   connect(imLimitedLeadLag2.y, K_r.u) annotation (Line(points={{71,0},{78,0},{78,0.5}}, color={0,0,127}));
-  connect(lV_Gate.p, VERR1.u2) annotation (Line(points={{-27.375,6},{-22,6}}, color={0,0,127}));
-  connect(hV_Gate.p, lV_Gate.n2) annotation (Line(points={{-59.625,3},{-54.8125,3},{-54.8125,3},{-49.375,3}}, color={0,0,127}));
-  connect(hV_Gate.n2, DiffV.y) annotation (Line(points={{-85.625,-0.5},{-91.8125,-0.5},{-91.8125,0},{-99,0}}, color={0,0,127}));
-  connect(hV_Gate.n1, VUEL) annotation (Line(points={{-85.625,6.5},{-92,6.5},{-92,-160},{-130,-160},{-130,-200}}, color={0,0,127}));
-  connect(lV_Gate.n1, VOEL) annotation (Line(points={{-49.375,9},{-54,9},{-54,-160},{-70,-160},{-70,-200}}, color={0,0,127}));
+  connect(lV_Gate.y, VERR1.u2) annotation (Line(points={{-27.375,6},{-22,6}}, color={0,0,127}));
+  connect(hV_Gate.y,lV_Gate.u2)  annotation (Line(points={{-59.625,3},{-54.8125,3},{-54.8125,3},{-49.375,3}}, color={0,0,127}));
+  connect(hV_Gate.u2, DiffV.y) annotation (Line(points={{-85.625,-0.5},{-91.8125,-0.5},{-91.8125,0},{-99,0}}, color={0,0,127}));
+  connect(hV_Gate.u1, VUEL) annotation (Line(points={{-85.625,6.5},{-92,6.5},{-92,-160},{-130,-160},{-130,-200}}, color={0,0,127}));
+  connect(lV_Gate.u1, VOEL) annotation (Line(points={{-49.375,9},{-54,9},{-54,-160},{-70,-160},{-70,-200}}, color={0,0,127}));
   connect(K_r.y, limiter.u) annotation (Line(points={{101,0.5},{104.5,0.5},{104.5,0},{106,0}}, color={0,0,127}));
   connect(limiter.y, VERR2.u2) annotation (Line(points={{129,0},{132,0},{132,6},{138,6}}, color={0,0,127}));
   connect(simpleLagLimVar.y, EFD) annotation (Line(points={{195,0},{210,0},{210,0}}, color={0,0,127}));

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/URST5T.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/URST5T.mo
@@ -80,15 +80,15 @@ equation
     annotation (Line(points={{-200,0},{-186,0},{-172,0}}, color={0,0,127}));
   connect(TransducerDelay.y, DiffV.u2) annotation (Line(points={{-149,0},{-132,
           0},{-132,-6},{-122,-6}}, color={0,0,127}));
-  connect(VUEL, hV_Gate.n1) annotation (Line(points={{-130,-200},{-130,-200},{-130,
+  connect(VUEL,hV_Gate.u1)  annotation (Line(points={{-130,-200},{-130,-200},{-130,
           -20},{-90,-20},{-90,3},{-87.375,3}}, color={0,0,127}));
-  connect(DiffV.y, hV_Gate.n2) annotation (Line(points={{-99,0},{-92,0},{-92,-3},
+  connect(DiffV.y,hV_Gate.u2)  annotation (Line(points={{-99,0},{-92,0},{-92,-3},
           {-87.375,-3}}, color={0,0,127}));
-  connect(VOEL, lV_Gate.n2) annotation (Line(points={{-70,-200},{-70,-200},{-70,
+  connect(VOEL,lV_Gate.u2)  annotation (Line(points={{-70,-200},{-70,-200},{-70,
           -34},{-70,-20},{-60,-20},{-60,-3},{-57.5,-3}}, color={0,0,127}));
-  connect(hV_Gate.p, lV_Gate.n1) annotation (Line(points={{-65.375,0},{-62,0},{
+  connect(hV_Gate.y,lV_Gate.u1)  annotation (Line(points={{-65.375,0},{-62,0},{
           -62,3},{-57.5,3}}, color={0,0,127}));
-  connect(lV_Gate.p, VERR1.u1) annotation (Line(points={{-33.5,0},{-30,0},{-30,
+  connect(lV_Gate.y, VERR1.u1) annotation (Line(points={{-33.5,0},{-30,0},{-30,
           -6},{-22,-6}}, color={0,0,127}));
   connect(VOTHSG, VERR1.u2) annotation (Line(points={{-200,90},{-200,90},{-30,
           90},{-30,6},{-22,6}}, color={0,0,127}));

--- a/OpenIPSL/Electrical/Controls/PSSE/ES/URST5T.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/ES/URST5T.mo
@@ -12,12 +12,12 @@ model URST5T "IEEE Proposed Type ST5B Excitation System [IEEE2005]"
   parameter Real T_1=0.58 "Thyristor bridge firing control equivalent time constant";
   parameter Real K_C=0.3 "Rectifier loading factor proportional to commutating reactance";
   Modelica.Blocks.Math.Add VERR1 annotation (Placement(transformation(
-        extent={{-10,10},{10,-10}},
+        extent={{-10,-10},{10,10}},
         origin={-10,0})));
   NonElectrical.Logical.LV_GATE lV_Gate
-    annotation (Placement(transformation(extent={{-56,-6},{-32,6}})));
+    annotation (Placement(transformation(extent={{-52,-10},{-32,10}})));
   NonElectrical.Logical.HV_GATE hV_Gate
-    annotation (Placement(transformation(extent={{-86,-6},{-64,6}})));
+    annotation (Placement(transformation(extent={{-86,-10},{-66,10}})));
   NonElectrical.Continuous.LeadLagLim LL1(
     K=1,
     outMax=V_RMAX/KR,
@@ -80,18 +80,10 @@ equation
     annotation (Line(points={{-200,0},{-186,0},{-172,0}}, color={0,0,127}));
   connect(TransducerDelay.y, DiffV.u2) annotation (Line(points={{-149,0},{-132,
           0},{-132,-6},{-122,-6}}, color={0,0,127}));
-  connect(VUEL,hV_Gate.u1)  annotation (Line(points={{-130,-200},{-130,-200},{-130,
-          -20},{-90,-20},{-90,3},{-87.375,3}}, color={0,0,127}));
-  connect(DiffV.y,hV_Gate.u2)  annotation (Line(points={{-99,0},{-92,0},{-92,-3},
-          {-87.375,-3}}, color={0,0,127}));
-  connect(VOEL,lV_Gate.u2)  annotation (Line(points={{-70,-200},{-70,-200},{-70,
-          -34},{-70,-20},{-60,-20},{-60,-3},{-57.5,-3}}, color={0,0,127}));
-  connect(hV_Gate.y,lV_Gate.u1)  annotation (Line(points={{-65.375,0},{-62,0},{
-          -62,3},{-57.5,3}}, color={0,0,127}));
-  connect(lV_Gate.y, VERR1.u1) annotation (Line(points={{-33.5,0},{-30,0},{-30,
-          -6},{-22,-6}}, color={0,0,127}));
-  connect(VOTHSG, VERR1.u2) annotation (Line(points={{-200,90},{-200,90},{-30,
-          90},{-30,6},{-22,6}}, color={0,0,127}));
+  connect(VOEL,lV_Gate.u2)  annotation (Line(points={{-70,-200},{-70,-100},{-60,-100},{-60,-6},{-54,-6}},
+                                                         color={0,0,127}));
+  connect(hV_Gate.y,lV_Gate.u1)  annotation (Line(points={{-65,0},{-60,0},{-60,6},{-54,6}},
+                             color={0,0,127}));
   connect(LL2.y, K_R.u)
     annotation (Line(points={{61,0},{61,0},{68,0}}, color={0,0,127}));
   connect(K_R.y, limiter.u)
@@ -113,6 +105,10 @@ equation
   connect(Vmax.y, simpleLagLimVar.outMax) annotation (Line(points={{139,90},{
           128,90},{128,20},{148,20},{148,14}}, color={0,0,127}));
   connect(K_c.u, XADIFD) annotation (Line(points={{160,-42},{160,-140},{80,-140},{80,-200}}, color={0,0,127}));
+  connect(VUEL, hV_Gate.u2) annotation (Line(points={{-130,-200},{-130,-100},{-94,-100},{-94,-6},{-88,-6}}, color={0,0,127}));
+  connect(DiffV.y, hV_Gate.u1) annotation (Line(points={{-99,0},{-94,0},{-94,6},{-88,6}}, color={0,0,127}));
+  connect(lV_Gate.y, VERR1.u2) annotation (Line(points={{-31,0},{-28,0},{-28,-6},{-22,-6}}, color={0,0,127}));
+  connect(VERR1.u1, VOTHSG) annotation (Line(points={{-22,6},{-28,6},{-28,90},{-200,90}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(extent={{-200,-200},{200,160}})),
     Icon(coordinateSystem(

--- a/OpenIPSL/Electrical/Controls/PSSE/TG/GAST.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/TG/GAST.mo
@@ -12,104 +12,103 @@ model GAST "GAST - Gas Turbine-Governor"
   parameter Types.PerUnit V_MIN=-0.05 "Low output control limit on fuel valve opening";
   parameter Types.PerUnit D_turb=0.0 "Turbine damping";
   Modelica.Blocks.Math.Add add(k1=-1)
-    annotation (Placement(transformation(extent={{-78,-12},{-68,-22}})));
+    annotation (Placement(transformation(extent={{-80,16},{-60,-4}})));
   Modelica.Blocks.Math.Add add1(k2=-1) annotation (Placement(transformation(
-        extent={{-5,-5},{5,5}},
+        extent={{-10,-10},{10,10}},
         rotation=180,
-        origin={25,-47})));
+        origin={40,-50})));
   Modelica.Blocks.Math.Add add2(k2=+1) annotation (Placement(transformation(
-        extent={{-5,-5},{5,5}},
+        extent={{-10,-10},{10,10}},
         rotation=180,
-        origin={-37,-47})));
+        origin={-20,-56})));
   Modelica.Blocks.Math.Add add3(k1=-1)
-    annotation (Placement(transformation(extent={{80,-5},{90,5}})));
+    annotation (Placement(transformation(extent={{120,-10},{140,10}})));
   Modelica.Blocks.Math.Gain gDturb(k=D_turb)
-    annotation (Placement(transformation(extent={{-54,55},{-44,65}})));
+    annotation (Placement(transformation(extent={{-40,29},{-20,50}})));
   Modelica.Blocks.Math.Gain gKt(k=K_T) annotation (Placement(transformation(
-        extent={{-5,-5},{5,5}},
+        extent={{-10,-10},{10,10}},
         rotation=180,
-        origin={-11,-45})));
+        origin={10,-50})));
   Modelica.Blocks.Math.Gain g1_R(k=1/R) annotation (Placement(transformation(
-        extent={{-5,-5},{5,5}},
-        origin={-133,-19})));
+        extent={{-10,-10},{10,10}},
+        origin={-110,0})));
   NonElectrical.Logical.LV_GATE lV_Gate
-    annotation (Placement(transformation(extent={{-46,-10},{-26,10}})));
+    annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   Modelica.Blocks.Continuous.TransferFunction transferFunction1(a={T_2,1},
     initType=Modelica.Blocks.Types.Init.InitialOutput,
     y_start=pm0)
-    annotation (Placement(transformation(extent={{48,-6},{60,6}})));
+    annotation (Placement(transformation(extent={{40,-10},{60,10}})));
   Modelica.Blocks.Continuous.TransferFunction transferFunction2(a={T_3,1},
     initType=Modelica.Blocks.Types.Init.InitialOutput,
     y_start=pm0)
     annotation (Placement(transformation(
-        extent={{-6,-6},{6,6}},
+        extent={{-10,-10},{10,10}},
         rotation=180,
-        origin={54,-40})));
+        origin={80,-30})));
   Modelica.Blocks.Sources.Constant const(k=AT)
-    annotation (Placement(transformation(extent={{-48,-94},{-28,-74}})));
+    annotation (Placement(transformation(extent={{90,-80},{70,-60}})));
   NonElectrical.Continuous.SimpleLagLim simpleLagLim(
     outMax=V_MAX,
     outMin=V_MIN,
     K=1,
     T=T_1,
-    y_start=pm0) annotation (Placement(transformation(extent={{-4,-4},{6,6}})));
+    y_start=pm0) annotation (Placement(transformation(extent={{0,-10},{20,10}})));
 protected
   parameter Types.PerUnit pm0(fixed=false);
 initial algorithm
   pm0 := PMECH0;
 equation
   connect(gDturb.y, add3.u1) annotation (Line(
-      points={{-43.5,60},{72,60},{72,3},{79,3}},
+      points={{-19,39.5},{100,39.5},{100,6},{118,6}},
       color={0,0,127},
       smooth=Smooth.None));
   connect(g1_R.y, add.u1) annotation (Line(
-      points={{-127.5,-19},{-127.5,-20},{-79,-20}},
+      points={{-99,0},{-82,0}},
       color={0,0,127},
       smooth=Smooth.None));
   connect(add1.y, gKt.u) annotation (Line(
-      points={{19.5,-47},{-5,-47},{-5,-45}},
+      points={{29,-50},{22,-50}},
       color={0,0,127},
       smooth=Smooth.None));
   connect(gKt.y, add2.u2) annotation (Line(
-      points={{-16.5,-45},{-31,-45},{-31,-44}},
+      points={{-1,-50},{-8,-50}},
       color={0,0,127},
       smooth=Smooth.None));
   connect(transferFunction2.y, add1.u2) annotation (Line(
-      points={{47.4,-40},{40,-40},{40,-44},{31,-44}},
+      points={{69,-30},{60,-30},{60,-44},{52,-44}},
       color={0,0,127},
       smooth=Smooth.None));
   connect(transferFunction1.y, add3.u2) annotation (Line(
-      points={{60.6,0},{70,0},{70,-3},{79,-3}},
+      points={{61,0},{100,0},{100,-6},{118,-6}},
       color={0,0,127},
       smooth=Smooth.None));
   connect(transferFunction1.y, transferFunction2.u) annotation (Line(
-      points={{60.6,0},{68,0},{68,-40},{61.2,-40}},
+      points={{61,0},{100,0},{100,-30},{92,-30}},
       color={0,0,127},
       smooth=Smooth.None));
   connect(add.y,lV_Gate.u1)  annotation (Line(
-      points={{-67.5,-17},{-55.75,-17},{-55.75,5},{-47.25,5}},
+      points={{-59,6},{-42,6}},
       color={0,0,127},
       smooth=Smooth.None));
   connect(lV_Gate.u2, add2.y) annotation (Line(
-      points={{-47.25,-5},{-47.25,-25.3},{-42.5,-25.3},{-42.5,-47}},
+      points={{-42,-6},{-48,-6},{-48,-56},{-31,-56}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(const.y, add2.u1) annotation (Line(points={{-27,-84},{-8,-84},{-8,-50},
-          {-31,-50}}, color={0,0,127}));
-  connect(add1.u1, add2.u1) annotation (Line(points={{31,-50},{38,-50},{38,-84},
-          {-8,-84},{-8,-50},{-31,-50}}, color={0,0,127}));
-  connect(simpleLagLim.u,lV_Gate.y)  annotation (Line(points={{-5,1},{-17.5,1},
-          {-17.5,0},{-27.25,0}}, color={0,0,127}));
-  connect(simpleLagLim.y, transferFunction1.u) annotation (Line(points={{6.5,1},
-          {26.25,1},{26.25,0},{46.8,0}}, color={0,0,127}));
+  connect(const.y, add2.u1) annotation (Line(points={{69,-70},{0,-70},{0,-62},{-8,-62}},
+                      color={0,0,127}));
+  connect(simpleLagLim.u,lV_Gate.y)  annotation (Line(points={{-2,0},{-19,0}},
+                                 color={0,0,127}));
+  connect(simpleLagLim.y, transferFunction1.u) annotation (Line(points={{21,0},{38,0}},
+                                         color={0,0,127}));
   connect(add3.y, PMECH)
-    annotation (Line(points={{90.5,0},{250,0}}, color={0,0,127}));
-  connect(SPEED, g1_R.u) annotation (Line(points={{-240,-120},{-152,-120},{-152,
-          -19},{-139,-19}}, color={0,0,127}));
-  connect(gDturb.u, g1_R.u) annotation (Line(points={{-55,60},{-152,60},{-152,-19},
-          {-139,-19}}, color={0,0,127}));
-  connect(add.u2, PMECH0) annotation (Line(points={{-79,-14},{-96,-14},{-96,80},
-          {-240,80}}, color={0,0,127}));
+    annotation (Line(points={{141,0},{250,0}},  color={0,0,127}));
+  connect(SPEED, g1_R.u) annotation (Line(points={{-240,-120},{-152,-120},{-152,0},{-122,0}},
+                            color={0,0,127}));
+  connect(gDturb.u, g1_R.u) annotation (Line(points={{-42,39.5},{-152,39.5},{-152,0},{-122,0}},
+                       color={0,0,127}));
+  connect(add.u2, PMECH0) annotation (Line(points={{-82,12},{-96,12},{-96,80},{-240,80}},
+                      color={0,0,127}));
+  connect(add1.u1, const.y) annotation (Line(points={{52,-56},{60,-56},{60,-70},{69,-70}}, color={0,0,127}));
   annotation (
     Diagram(coordinateSystem(
         extent={{-240,-200},{240,180}},

--- a/OpenIPSL/Electrical/Controls/PSSE/TG/GAST.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/TG/GAST.mo
@@ -86,11 +86,11 @@ equation
       points={{60.6,0},{68,0},{68,-40},{61.2,-40}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(add.y, lV_Gate.n1) annotation (Line(
+  connect(add.y,lV_Gate.u1)  annotation (Line(
       points={{-67.5,-17},{-55.75,-17},{-55.75,5},{-47.25,5}},
       color={0,0,127},
       smooth=Smooth.None));
-  connect(lV_Gate.n2, add2.y) annotation (Line(
+  connect(lV_Gate.u2, add2.y) annotation (Line(
       points={{-47.25,-5},{-47.25,-25.3},{-42.5,-25.3},{-42.5,-47}},
       color={0,0,127},
       smooth=Smooth.None));
@@ -98,7 +98,7 @@ equation
           {-31,-50}}, color={0,0,127}));
   connect(add1.u1, add2.u1) annotation (Line(points={{31,-50},{38,-50},{38,-84},
           {-8,-84},{-8,-50},{-31,-50}}, color={0,0,127}));
-  connect(simpleLagLim.u, lV_Gate.p) annotation (Line(points={{-5,1},{-17.5,1},
+  connect(simpleLagLim.u,lV_Gate.y)  annotation (Line(points={{-5,1},{-17.5,1},
           {-17.5,0},{-27.25,0}}, color={0,0,127}));
   connect(simpleLagLim.y, transferFunction1.u) annotation (Line(points={{6.5,1},
           {26.25,1},{26.25,0},{46.8,0}}, color={0,0,127}));

--- a/OpenIPSL/NonElectrical/Logical/HV_GATE.mo
+++ b/OpenIPSL/NonElectrical/Logical/HV_GATE.mo
@@ -1,26 +1,15 @@
 within OpenIPSL.NonElectrical.Logical;
-model HV_GATE
-  Modelica.Blocks.Interfaces.RealInput u1 annotation (Placement(transformation(
-          extent={{-86,-2},{-46,38}}), iconTransformation(extent={{-100,10},{-80,
-            30}})));
-  Modelica.Blocks.Interfaces.RealInput u2 annotation (Placement(transformation(
-          extent={{-86,-50},{-46,-10}}), iconTransformation(extent={{-100,-30},
-            {-80,-10}})));
-  Modelica.Blocks.Interfaces.RealOutput y annotation (Placement(transformation(
-          extent={{-208,54},{-188,74}}), iconTransformation(extent={{60,-10},{
-            80,10}})));
-equation
-  y = if u1 <u2  then u2 else u1;
-  annotation (
-    Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-80,-40},{80,40}})),
-    Icon(coordinateSystem(preserveAspectRatio=true, extent={{-80,-40},{80,40}}),
-        graphics={Polygon(
-          points={{-80,40},{-80,-40},{0,-40},{80,0},{0,40},{-80,40}},
+block HV_GATE "Passes through the higher value of the two inputs"
+  extends Modelica.Blocks.Math.Max;
+  annotation (Icon(graphics={Polygon(
+          points={{-100,100},{40,100},{100,0},{40,-100},{-100,-100},{-100,100}},
+          lineColor={28,108,200},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid), Text(
+          extent={{-100,40},{60,-40}},
           lineColor={0,0,255},
           fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),Text(
-          extent={{-64,14},{-2,-14}},
-          lineColor={0,0,255},
+          fillPattern=FillPattern.None,
           textString="HV
-Gate")}));
+GATE")}));
 end HV_GATE;

--- a/OpenIPSL/NonElectrical/Logical/HV_GATE.mo
+++ b/OpenIPSL/NonElectrical/Logical/HV_GATE.mo
@@ -1,19 +1,18 @@
 within OpenIPSL.NonElectrical.Logical;
 model HV_GATE
-  Modelica.Blocks.Interfaces.RealInput n1 annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealInput u1 annotation (Placement(transformation(
           extent={{-86,-2},{-46,38}}), iconTransformation(extent={{-100,10},{-80,
             30}})));
-  Modelica.Blocks.Interfaces.RealInput n2 annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealInput u2 annotation (Placement(transformation(
           extent={{-86,-50},{-46,-10}}), iconTransformation(extent={{-100,-30},
             {-80,-10}})));
-  Modelica.Blocks.Interfaces.RealOutput p annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealOutput y annotation (Placement(transformation(
           extent={{-208,54},{-188,74}}), iconTransformation(extent={{60,-10},{
             80,10}})));
 equation
-  p = if n1 < n2 then n2 else n1;
+  y = if u1 <u2  then u2 else u1;
   annotation (
-    Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-80,-40},{80,40}}),
-        graphics),
+    Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-80,-40},{80,40}})),
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-80,-40},{80,40}}),
         graphics={Polygon(
           points={{-80,40},{-80,-40},{0,-40},{80,0},{0,40},{-80,40}},

--- a/OpenIPSL/NonElectrical/Logical/LV_GATE.mo
+++ b/OpenIPSL/NonElectrical/Logical/LV_GATE.mo
@@ -1,8 +1,6 @@
 within OpenIPSL.NonElectrical.Logical;
 block LV_GATE "Passes through the lower value of the two inputs"
   extends Modelica.Blocks.Math.Min;
-equation
-  connect(y, y) annotation (Line(points={{110,0},{110,0}}, color={0,0,127}));
   annotation (Icon(graphics={Polygon(
           points={{-100,100},{40,100},{100,0},{40,-100},{-100,-100},{-100,100}},
           lineColor={28,108,200},

--- a/OpenIPSL/NonElectrical/Logical/LV_GATE.mo
+++ b/OpenIPSL/NonElectrical/Logical/LV_GATE.mo
@@ -1,26 +1,17 @@
 within OpenIPSL.NonElectrical.Logical;
-model LV_GATE
-  Modelica.Blocks.Interfaces.RealInput u1 annotation (Placement(transformation(
-          extent={{-86,-2},{-46,38}}), iconTransformation(extent={{-100,10},{-80,
-            30}})));
-  Modelica.Blocks.Interfaces.RealInput u2 annotation (Placement(transformation(
-          extent={{-86,-50},{-46,-10}}), iconTransformation(extent={{-100,-30},
-            {-80,-10}})));
-  Modelica.Blocks.Interfaces.RealOutput y annotation (Placement(transformation(
-          extent={{-208,58},{-188,78}}), iconTransformation(extent={{60,-10},{
-            80,10}})));
+block LV_GATE "Passes through the lower value of the two inputs"
+  extends Modelica.Blocks.Math.Min;
 equation
-  y = if u1 >u2  then u2 else u1;
-  annotation (
-    Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-80,-40},{80,40}})),
-    Icon(coordinateSystem(preserveAspectRatio=true, extent={{-80,-40},{80,40}}),
-        graphics={Polygon(
-          points={{-80,40},{-80,-40},{0,-40},{80,0},{0,40},{-80,40}},
+  connect(y, y) annotation (Line(points={{110,0},{110,0}}, color={0,0,127}));
+  annotation (Icon(graphics={Polygon(
+          points={{-100,100},{40,100},{100,0},{40,-100},{-100,-100},{-100,100}},
+          lineColor={28,108,200},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid), Text(
+          extent={{-100,40},{60,-40}},
           lineColor={0,0,255},
           fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),Text(
-          extent={{-60,20},{0,-20}},
-          lineColor={0,0,255},
+          fillPattern=FillPattern.None,
           textString="LV
-Gate")}));
+GATE")}));
 end LV_GATE;

--- a/OpenIPSL/NonElectrical/Logical/LV_GATE.mo
+++ b/OpenIPSL/NonElectrical/Logical/LV_GATE.mo
@@ -1,19 +1,18 @@
 within OpenIPSL.NonElectrical.Logical;
 model LV_GATE
-  Modelica.Blocks.Interfaces.RealInput n1 annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealInput u1 annotation (Placement(transformation(
           extent={{-86,-2},{-46,38}}), iconTransformation(extent={{-100,10},{-80,
             30}})));
-  Modelica.Blocks.Interfaces.RealInput n2 annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealInput u2 annotation (Placement(transformation(
           extent={{-86,-50},{-46,-10}}), iconTransformation(extent={{-100,-30},
             {-80,-10}})));
-  Modelica.Blocks.Interfaces.RealOutput p annotation (Placement(transformation(
+  Modelica.Blocks.Interfaces.RealOutput y annotation (Placement(transformation(
           extent={{-208,58},{-188,78}}), iconTransformation(extent={{60,-10},{
             80,10}})));
 equation
-  p = if n1 > n2 then n2 else n1;
+  y = if u1 >u2  then u2 else u1;
   annotation (
-    Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-80,-40},{80,40}}),
-        graphics),
+    Diagram(coordinateSystem(preserveAspectRatio=true, extent={{-80,-40},{80,40}})),
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-80,-40},{80,40}}),
         graphics={Polygon(
           points={{-80,40},{-80,-40},{0,-40},{80,0},{0,40},{-80,40}},

--- a/OpenIPSL/Resources/Scripts/ConvertOpenIPSL_from_1.5.0_to_2.0.0.mos
+++ b/OpenIPSL/Resources/Scripts/ConvertOpenIPSL_from_1.5.0_to_2.0.0.mos
@@ -380,6 +380,11 @@ convertMessage({"OpenIPSL.NonElectrical.Logical.Relay4"},
                 "This model was removed without replacement, no support of automatic conversion.");
 
 
+convertElement("OpenIPSL.NonElectrical.Logical.HV_GATE",
+               {"n1","n2","p"},{"u1","u2","y"});
+convertElement("OpenIPSL.NonElectrical.Logical.LV_GATE",
+               {"n1","n2","p"},{"u1","u2","y"});
+
 /* Interfaces */
 
 // Interfaces.Generator


### PR DESCRIPTION
This keeps the visual appearance but at the same time extends the Min and Max blocks from the MSL. 
Conversion script takes care of the rename of the connector names.