### PR TITLE
Avoid equality on Real variables in SE Non-electrical function

### DIFF
--- a/OpenIPSL/NonElectrical/Functions/SE.mo
+++ b/OpenIPSL/NonElectrical/Functions/SE.mo
@@ -8,12 +8,12 @@ function SE "Scaled Quadratic Saturation Function (PTI PSS/E) "
   input Real E2;
   output Real sys "Saturated Output";
 protected
-  parameter Real a=if SE2 <> 0 then sqrt(SE1*E1/(SE2*E2)) else 0;
+  parameter Real a=if not (SE2 > 0.0 or SE2 < 0.0) then sqrt(SE1*E1/(SE2*E2)) else 0;
   parameter Real A=E2 - (E1 - E2)/(a - 1);
   parameter Real B=if abs(E1 - E2) < Modelica.Constants.eps then 0 else SE2*E2*
       (a - 1)^2/(E1 - E2)^2;
 algorithm
-  if SE1 == 0.0 or u <= 0.0 then
+  if not (SE1 > 0.0 or SE1 < 0.0) or u <= 0.0 then
     sys := 0.0;
   else
     if u <= A then


### PR DESCRIPTION
This eliminates many errors when simulating the CIM translated IEEE14 in WSM 13.2 because of it's effect on PSSE.GENROU.