### PR TITLE
Graphical enhancements of line model and IEEE14 example

### DIFF
--- a/OpenIPSL/Electrical/Branches/PSAT/TwoWindingTransformer.mo
+++ b/OpenIPSL/Electrical/Branches/PSAT/TwoWindingTransformer.mo
@@ -5,9 +5,9 @@ model TwoWindingTransformer "Modeled as series reactances without iron losses"
   import Modelica.ComplexMath.real;
   import Modelica.ComplexMath.imag;
   import Modelica.ComplexMath.j;
-  OpenIPSL.Interfaces.PwPin p
+  OpenIPSL.Interfaces.PwPin_p p
     annotation (Placement(transformation(extent={{-120,-10},{-100,10}})));
-  OpenIPSL.Interfaces.PwPin n
+  OpenIPSL.Interfaces.PwPin_n n
     annotation (Placement(transformation(extent={{100,-10},{120,10}})));
   parameter Types.ApparentPower S_b=SysData.S_b "System base power"
     annotation (Dialog(group="Power flow"));

--- a/OpenIPSL/Electrical/Branches/PwLine.mo
+++ b/OpenIPSL/Electrical/Branches/PwLine.mo
@@ -5,9 +5,9 @@ model PwLine "Model for a transmission Line based on the pi-equivalent circuit"
   import Modelica.ComplexMath.real;
   import Modelica.ComplexMath.imag;
   import Modelica.ComplexMath.j;
-  OpenIPSL.Interfaces.PwPin p annotation (Placement(transformation(extent={{-100,
+  OpenIPSL.Interfaces.PwPin_p p annotation (Placement(transformation(extent={{-100,
             -10},{-80,10}}), iconTransformation(extent={{-100,-10},{-80,10}})));
-  OpenIPSL.Interfaces.PwPin n annotation (Placement(transformation(extent={{80,
+  OpenIPSL.Interfaces.PwPin_n n annotation (Placement(transformation(extent={{80,
             -10},{100,10}}), iconTransformation(extent={{80,-10},{100,10}})));
   parameter Types.PerUnit R "Resistance"
     annotation (Dialog(group="Line parameters"));

--- a/OpenIPSL/Electrical/Branches/PwLine.mo
+++ b/OpenIPSL/Electrical/Branches/PwLine.mo
@@ -72,10 +72,6 @@ equation
           extent={{-80,40},{80,-40}},
           lineColor={0,0,255},
           fillColor={255,255,255},
-          fillPattern=FillPattern.Solid),Rectangle(
-          extent={{-60,20},{60,-20}},
-          lineColor={0,0,255},
-          fillColor={95,95,95},
           fillPattern=FillPattern.Solid),Text(
           visible=displayPF,
           extent={{-200,160},{-20,40}},
@@ -127,7 +123,7 @@ equation
           lineColor={0,255,0},
           fillColor={0,255,0},
           fillPattern=FillPattern.Solid),Text(
-          extent={{-60,20},{60,-20}},
-          lineColor={255,255,0},
+          extent={{-80,12},{80,-14}},
+          lineColor={0,0,0},
           textString="%name")}));
 end PwLine;

--- a/OpenIPSL/Electrical/Loads/PSAT/BaseClasses/baseLoad.mo
+++ b/OpenIPSL/Electrical/Loads/PSAT/BaseClasses/baseLoad.mo
@@ -26,10 +26,13 @@ equation
   annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},
             {100,100}}), graphics={Line(points={{-100,100},{100,100},{0,-100},{
           -100,100}}, color={28,108,200}),Text(
-          extent={{-60,80},{60,40}},
-          lineColor={28,108,200},
-          textString="%P_0+j%Q_0"),Text(
+          extent={{-100,80},{100,56}},
+          lineColor={0,0,0},
+          textString="%P_0"),      Text(
           extent={{-150,-110},{150,-150}},
           lineColor={0,0,255},
-          textString="%name")}));
+          textString="%name"),            Text(
+          extent={{-100,32},{100,6}},
+          lineColor={0,0,0},
+          textString="%Q_0")}));
 end baseLoad;

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus1.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus1.mo
@@ -56,7 +56,7 @@ equation
           lineColor={0,0,255},
           textStyle={TextStyle.Italic},
           textString=""),
-          Text(extent={{-34,-32},{38,-52}},
+          Text(extent={{-100,-34},{100,-50}},
           lineColor={28,108,200},
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus1.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus1.mo
@@ -35,40 +35,36 @@ model GroupBus1 "69kV/615MVA generation unit connected to bus 1"
     P_0=P_0,
     Q_0=Q_0) annotation (Placement(transformation(extent={{40,-20},{80,20}})));
   OpenIPSL.Interfaces.PwPin pwPin annotation (Placement(transformation(extent={{100,-10},
-            {120,10}}), iconTransformation(extent={{100,-10},{120,10}})));
+            {120,10}}),          iconTransformation(extent={{100,-10},{120,10}})));
 equation
   connect(AVR1.vf, Syn1.vf) annotation (Line(points={{14,10},{36,10}},
                         color={0,0,127}));
   connect(Syn1.v, AVR1.v) annotation (Line(points={{82,6},{88,6},{88,-30},{-16,-30},
-          {-16,4},{-10,4}}, color={0,0,127}));
+          {-16,4},{-10,4}},                         color={0,0,127}));
   connect(Syn1.p, pwPin) annotation (Line(points={{80,0},{110,0}},
                      color={0,0,255}));
   connect(Syn1.pm0, Syn1.pm) annotation (Line(points={{44,-22},{44,-26},{28,-26},
-          {28,-10},{36,-10}}, color={0,0,127}));
+          {28,-10},{36,-10}},               color={0,0,127}));
   connect(AVR1.vref0, AVR1.vref) annotation (Line(points={{2,22},{2,26},{-16,26},
-          {-16,16},{-10,16}}, color={0,0,127}));
+          {-16,16},{-10,16}},                                  color={0,0,127}));
   connect(AVR1.vf0, Syn1.vf0) annotation (Line(points={{2,-2},{2,-12},{20,-12},{
-          20,26},{44,26},{44,22}}, color={0,0,127}));
+          20,26},{44,26},{44,22}},            color={0,0,127}));
   annotation (
     Icon(coordinateSystem(extent={{-100,-100},{100,100}}, preserveAspectRatio=
-            false),graphics={Text(
-          extent={{-93,6},{-24,-12}},
-          lineColor={0,0,255},
-          textStyle={TextStyle.Italic},
-          textString=""),
-          Text(extent={{-100,-34},{100,-50}},
-          lineColor={28,108,200},
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid,
-          textString="%name"),
-                         Line(points={{-60,-20},{-20,20},{20,-20},{60,20}},
-          color={28,108,200}),Ellipse(extent={{-100,-100},{100,100}}, lineColor=
-           {28,108,200})}),
+            false),graphics={Text(lineColor = {0, 0, 255}, extent = {{-93, 6}, {-24, -12}}, textString = "", textStyle = {TextStyle.Italic}),
+       Text(origin={-7.1542,-4.28575},
+            lineColor = {28, 108, 200}, fillColor = {0, 0, 255},
+            fillPattern = FillPattern.Solid,
+              extent={{
+              -85.8458,-19.7143},{95.1542,-31.7143}},textString = "%name"),
+       Line(points={{-60,0},{-20,40},{20,0},{60,40}},
+       color={28,108,200}),Ellipse(lineColor = {28, 108, 200}, extent={{-100, -100},{100,100}})}),
     Documentation(info="<html>
 <p>69kV/615MVA Generation unit connected to bus 1, and composed of the following component models:</p>
 <ul>
 <li><strong>Machine</strong>: 5th order type 2, from PSAT.</li>
 <li><strong>Exciter</strong>: type II, from PSAT.</li>
 </ul>
-</html>"));
+</html>"),
+  Diagram(coordinateSystem(extent = {{-20, 40}, {120, -40}})));
 end GroupBus1;

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus1.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus1.mo
@@ -13,7 +13,7 @@ model GroupBus1 "69kV/615MVA generation unit connected to bus 1"
     vrmax=7.32,
     vrmin=0,
     Ka=200,
-    v0=v_0) annotation (Placement(transformation(extent={{-8,0},{12,20}})));
+    v0=v_0) annotation (Placement(transformation(extent={{-10,0},{10,20}})));
   OpenIPSL.Electrical.Machines.PSAT.Order5_Type2 Syn1(
     Sn=615000000,
     Vn=69000,
@@ -35,36 +35,35 @@ model GroupBus1 "69kV/615MVA generation unit connected to bus 1"
     P_0=P_0,
     Q_0=Q_0) annotation (Placement(transformation(extent={{40,-20},{80,20}})));
   OpenIPSL.Interfaces.PwPin pwPin annotation (Placement(transformation(extent={{100,-10},
-            {120,10}}),          iconTransformation(extent={{100,-10},{120,10}})));
+            {120,10}}), iconTransformation(extent={{100,-10},{120,10}})));
 equation
-  connect(AVR1.vf, Syn1.vf) annotation (Line(points={{14,10},{36,10}},
+  connect(AVR1.vf, Syn1.vf) annotation (Line(points={{12,10},{36,10}},
                         color={0,0,127}));
-  connect(Syn1.v, AVR1.v) annotation (Line(points={{82,6},{88,6},{88,-30},{-16,-30},
-          {-16,4},{-10,4}},                         color={0,0,127}));
+  connect(Syn1.v, AVR1.v) annotation (Line(points={{82,6},{90,6},{90,-32},{-20,-32},{-20,4},{-12,4}},
+                                                    color={0,0,127}));
   connect(Syn1.p, pwPin) annotation (Line(points={{80,0},{110,0}},
                      color={0,0,255}));
-  connect(Syn1.pm0, Syn1.pm) annotation (Line(points={{44,-22},{44,-26},{28,-26},
-          {28,-10},{36,-10}},               color={0,0,127}));
-  connect(AVR1.vref0, AVR1.vref) annotation (Line(points={{2,22},{2,26},{-16,26},
-          {-16,16},{-10,16}},                                  color={0,0,127}));
-  connect(AVR1.vf0, Syn1.vf0) annotation (Line(points={{2,-2},{2,-12},{20,-12},{
-          20,26},{44,26},{44,22}},            color={0,0,127}));
+  connect(Syn1.pm0, Syn1.pm) annotation (Line(points={{44,-22},{44,-28},{28,-28},{28,-10},{36,-10}},
+                                            color={0,0,127}));
+  connect(AVR1.vref0, AVR1.vref) annotation (Line(points={{0,22},{0,30},{-20,30},{-20,16},{-12,16}},
+                                                               color={0,0,127}));
+  connect(AVR1.vf0, Syn1.vf0) annotation (Line(points={{0,-2},{0,-12},{20,-12},{20,30},{44,30},{44,22}},
+                                              color={0,0,127}));
   annotation (
-    Icon(coordinateSystem(extent={{-100,-100},{100,100}}, preserveAspectRatio=
-            false),graphics={Text(lineColor = {0, 0, 255}, extent = {{-93, 6}, {-24, -12}}, textString = "", textStyle = {TextStyle.Italic}),
-       Text(origin={-7.1542,-4.28575},
-            lineColor = {28, 108, 200}, fillColor = {0, 0, 255},
-            fillPattern = FillPattern.Solid,
-              extent={{
-              -85.8458,-19.7143},{95.1542,-31.7143}},textString = "%name"),
+    Icon(graphics={Text(lineColor = {0, 0, 255}, extent = {{-93, 6}, {-24, -12}}, textString = "", textStyle = {TextStyle.Italic}),
+       Text(
+          lineColor={28,108,200},
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid,
+          extent={{-100,-20},{100,-40}},
+          textString="%name"),
        Line(points={{-60,0},{-20,40},{20,0},{60,40}},
-       color={28,108,200}),Ellipse(lineColor = {28, 108, 200}, extent={{-100, -100},{100,100}})}),
+       color={28,108,200}),Ellipse(lineColor = {28, 108, 200}, extent={{-100,-100},{100,100}})}),
     Documentation(info="<html>
 <p>69kV/615MVA Generation unit connected to bus 1, and composed of the following component models:</p>
 <ul>
 <li><strong>Machine</strong>: 5th order type 2, from PSAT.</li>
 <li><strong>Exciter</strong>: type II, from PSAT.</li>
 </ul>
-</html>"),
-  Diagram(coordinateSystem(extent = {{-20, 40}, {120, -40}})));
+</html>"));
 end GroupBus1;

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus2.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus2.mo
@@ -58,7 +58,7 @@ equation
             120,100}})),
     Icon(coordinateSystem(extent={{-100,-100},{100,100}}, preserveAspectRatio=
             false), graphics={
-            Text(extent={{-34,-32},{38,-52}},
+            Text(extent={{-100,-34},{100,-50}},
           lineColor={28,108,200},
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus2.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus2.mo
@@ -37,33 +37,33 @@ model GroupBus2 "69kV/60MVA generation unit connected to bus 2"
     P_0=P_0,
     Q_0=Q_0) annotation (Placement(transformation(extent={{42,-20},{82,20}})));
   OpenIPSL.Interfaces.PwPin pwPin annotation (Placement(transformation(extent={{100,-10},
-            {120,10}}), iconTransformation(extent={{100,-10},{120,10}})));
+            {120,10}}),          iconTransformation(extent={{100,-10},{120,10}})));
 equation
   connect(aVR1TypeII1.vf, Syn3.vf) annotation (Line(points={{16,10},{38,10}},
                                      color={0,0,127}));
   connect(Syn3.v, aVR1TypeII1.v) annotation (Line(points={{84,6},{90,6},{90,-32},
-          {-14,-32},{-14,4},{-8,4}}, color={
+          {-14,-32},{-14,4},{-8,4}},                                    color={
           0,0,127}));
   connect(Syn3.p, pwPin) annotation (Line(points={{82,0},{110,0}},
                     color={0,0,255}));
   connect(Syn3.pm0, Syn3.pm) annotation (Line(points={{46,-22},{46,-28},{28,-28},
-          {28,-10},{38,-10}}, color={0,0,127}));
+          {28,-10},{38,-10}},             color={0,0,127}));
   connect(Syn3.vf0, aVR1TypeII1.vf0) annotation (Line(points={{46,22},{46,28},{
-          24,28},{24,-28},{4,-28},{4,-2}}, color={0,0,127}));
+          24,28},{24,-28},{4,-28},{4,-2}},                     color={0,0,127}));
   connect(aVR1TypeII1.vref0, aVR1TypeII1.vref) annotation (Line(points={{4,22},{
-          4,28},{-14,28},{-14,16},{-8,16}}, color={0,0,
+          4,28},{-14,28},{-14,16},{-8,16}},                        color={0,0,
           127}));
   annotation (
-    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-120,-100},{
-            120,100}})),
+    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-20,-40},{120,
+            40}})),
     Icon(coordinateSystem(extent={{-100,-100},{100,100}}, preserveAspectRatio=
             false), graphics={
-            Text(extent={{-100,-34},{100,-50}},
+            Text(extent={{-98,-20},{100,-38}},
           lineColor={28,108,200},
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,
           textString="%name"),
-           Line(points={{-60,-20},{-20,20},{20,-20},{60,20}},
+           Line(points={{-60,0},{-20,40},{20,0},{60,40}},
           color={28,108,200}),Ellipse(extent={{-100,-100},{100,100}}, lineColor=
            {28,108,200})}),
     Documentation(info="<html>

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus2.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus2.mo
@@ -14,7 +14,7 @@ model GroupBus2 "69kV/60MVA generation unit connected to bus 2"
     v0=v_0,
     vrmin=0,
     vrmax=4.38)
-    annotation (Placement(transformation(extent={{-6,0},{14,20}})));
+    annotation (Placement(transformation(extent={{-10,0},{10,20}})));
   OpenIPSL.Electrical.Machines.PSAT.Order6 Syn3(
     Sn=60000000,
     Vn=69000,
@@ -35,30 +35,26 @@ model GroupBus2 "69kV/60MVA generation unit connected to bus 2"
     xd=1.05,
     angle_0=angle_0,
     P_0=P_0,
-    Q_0=Q_0) annotation (Placement(transformation(extent={{42,-20},{82,20}})));
+    Q_0=Q_0) annotation (Placement(transformation(extent={{40,-20},{80,20}})));
   OpenIPSL.Interfaces.PwPin pwPin annotation (Placement(transformation(extent={{100,-10},
-            {120,10}}),          iconTransformation(extent={{100,-10},{120,10}})));
+            {120,10}}), iconTransformation(extent={{100,-10},{120,10}})));
 equation
-  connect(aVR1TypeII1.vf, Syn3.vf) annotation (Line(points={{16,10},{38,10}},
+  connect(aVR1TypeII1.vf, Syn3.vf) annotation (Line(points={{12,10},{36,10}},
                                      color={0,0,127}));
-  connect(Syn3.v, aVR1TypeII1.v) annotation (Line(points={{84,6},{90,6},{90,-32},
-          {-14,-32},{-14,4},{-8,4}},                                    color={
+  connect(Syn3.v, aVR1TypeII1.v) annotation (Line(points={{82,6},{90,6},{90,-32},{-20,-32},{-20,4},{-12,4}},
+                                                                        color={
           0,0,127}));
-  connect(Syn3.p, pwPin) annotation (Line(points={{82,0},{110,0}},
+  connect(Syn3.p, pwPin) annotation (Line(points={{80,0},{110,0}},
                     color={0,0,255}));
-  connect(Syn3.pm0, Syn3.pm) annotation (Line(points={{46,-22},{46,-28},{28,-28},
-          {28,-10},{38,-10}},             color={0,0,127}));
-  connect(Syn3.vf0, aVR1TypeII1.vf0) annotation (Line(points={{46,22},{46,28},{
-          24,28},{24,-28},{4,-28},{4,-2}},                     color={0,0,127}));
-  connect(aVR1TypeII1.vref0, aVR1TypeII1.vref) annotation (Line(points={{4,22},{
-          4,28},{-14,28},{-14,16},{-8,16}},                        color={0,0,
+  connect(Syn3.pm0, Syn3.pm) annotation (Line(points={{44,-22},{44,-28},{28,-28},{28,-10},{36,-10}},
+                                          color={0,0,127}));
+  connect(Syn3.vf0, aVR1TypeII1.vf0) annotation (Line(points={{44,22},{44,30},{20,30},{20,-12},{0,-12},{0,-2}},
+                                                               color={0,0,127}));
+  connect(aVR1TypeII1.vref0, aVR1TypeII1.vref) annotation (Line(points={{0,22},{0,30},{-20,30},{-20,16},{-12,16}},
+                                                                   color={0,0,
           127}));
   annotation (
-    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-20,-40},{120,
-            40}})),
-    Icon(coordinateSystem(extent={{-100,-100},{100,100}}, preserveAspectRatio=
-            false), graphics={
-            Text(extent={{-98,-20},{100,-38}},
+    Icon(graphics={Text(extent={{-100,-20},{100,-40}},
           lineColor={28,108,200},
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus3.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus3.mo
@@ -40,25 +40,25 @@ model GroupBus3 "69kV/60MVA reactive power generation unit (synchronous condense
         extent={{-20,-20},{20,20}},
         origin={62,0})));
   OpenIPSL.Interfaces.PwPin pwPin annotation (Placement(transformation(extent={{100,-10},
-            {120,10}}), iconTransformation(extent={{100,-10},{120,10}})));
+            {120,10}}),         iconTransformation(extent={{100,-10},{120,10}})));
 equation
   connect(aVR2TypeII2.vf, Syn2.vf) annotation (Line(points={{16,10},{38,10}},
                               color={0,0,127}));
   connect(Syn2.v, aVR2TypeII2.v) annotation (Line(points={{84,6},{90,6},{90,-30},
-          {-14,-30},{-14,4},{-8,4}}, color={0,0,127}));
+          {-14,-30},{-14,4},{-8,4}},                    color={0,0,127}));
   connect(Syn2.p, pwPin) annotation (Line(points={{82,0},{110,0}},
                     color={0,0,255}));
   connect(Syn2.pm0, Syn2.pm) annotation (Line(points={{46,-22},{46,-26},{30,-26},
-          {30,-10},{38,-10}}, color={0,0,127}));
+          {30,-10},{38,-10}},             color={0,0,127}));
   connect(aVR2TypeII2.vref0, aVR2TypeII2.vref) annotation (Line(points={{4,22},{
-          4,28},{-14,28},{-14,16},{-8,16}}, color={0,0,
+          4,28},{-14,28},{-14,16},{-8,16}},                        color={0,0,
           127}));
   connect(Syn2.vf0, aVR2TypeII2.vf0) annotation (Line(points={{46,22},{46,28},{
-          26,28},{26,-26},{4,-26},{4,-2}}, color={0,0,
+          26,28},{26,-26},{4,-26},{4,-2}},                           color={0,0,
           127}));
   annotation (
-    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{
-            120,100}})),
+    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-20,-40},{120,
+            40}})),
     Icon(coordinateSystem(extent={{-100,-100},{100,100}}, preserveAspectRatio=
             false), graphics={
                              Text(
@@ -66,12 +66,12 @@ equation
           lineColor={0,0,255},
           textStyle={TextStyle.Italic},
           textString=""),
-          Text(extent={{-100,-34},{100,-50}},
+          Text(extent={{-96,-20},{96,-38}},
           lineColor={28,108,200},
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,
           textString="%name"),
-                         Line(points={{-60,-20},{-20,20},{20,-20},{60,20}},
+                         Line(points={{-60,0},{-20,40},{20,0},{60,40}},
           color={28,108,200}),Ellipse(extent={{-100,-100},{100,100}}, lineColor=
            {28,108,200})}),
     Documentation(info="<html>

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus3.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus3.mo
@@ -66,7 +66,7 @@ equation
           lineColor={0,0,255},
           textStyle={TextStyle.Italic},
           textString=""),
-          Text(extent={{-34,-32},{38,-52}},
+          Text(extent={{-100,-34},{100,-50}},
           lineColor={28,108,200},
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus3.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus3.mo
@@ -15,7 +15,7 @@ model GroupBus3 "69kV/60MVA reactive power generation unit (synchronous condense
     vrmin=0,
     vrmax=4.38) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
-        origin={4,10})));
+        origin={0,10})));
   OpenIPSL.Electrical.Machines.PSAT.Order6 Syn2(
     Sn=60000000,
     Vn=69000,
@@ -38,35 +38,32 @@ model GroupBus3 "69kV/60MVA reactive power generation unit (synchronous condense
     P_0=P_0,
     Q_0=Q_0) annotation (Placement(transformation(
         extent={{-20,-20},{20,20}},
-        origin={62,0})));
+        origin={60,0})));
   OpenIPSL.Interfaces.PwPin pwPin annotation (Placement(transformation(extent={{100,-10},
-            {120,10}}),         iconTransformation(extent={{100,-10},{120,10}})));
+            {120,10}}), iconTransformation(extent={{100,-10},{120,10}})));
 equation
-  connect(aVR2TypeII2.vf, Syn2.vf) annotation (Line(points={{16,10},{38,10}},
+  connect(aVR2TypeII2.vf, Syn2.vf) annotation (Line(points={{12,10},{36,10}},
                               color={0,0,127}));
-  connect(Syn2.v, aVR2TypeII2.v) annotation (Line(points={{84,6},{90,6},{90,-30},
-          {-14,-30},{-14,4},{-8,4}},                    color={0,0,127}));
-  connect(Syn2.p, pwPin) annotation (Line(points={{82,0},{110,0}},
+  connect(Syn2.v, aVR2TypeII2.v) annotation (Line(points={{82,6},{90,6},{90,-32},{-20,-32},{-20,4},{-12,4}},
+                                                        color={0,0,127}));
+  connect(Syn2.p, pwPin) annotation (Line(points={{80,0},{110,0}},
                     color={0,0,255}));
-  connect(Syn2.pm0, Syn2.pm) annotation (Line(points={{46,-22},{46,-26},{30,-26},
-          {30,-10},{38,-10}},             color={0,0,127}));
-  connect(aVR2TypeII2.vref0, aVR2TypeII2.vref) annotation (Line(points={{4,22},{
-          4,28},{-14,28},{-14,16},{-8,16}},                        color={0,0,
+  connect(Syn2.pm0, Syn2.pm) annotation (Line(points={{44,-22},{44,-28},{28,-28},{28,-10},{36,-10}},
+                                          color={0,0,127}));
+  connect(aVR2TypeII2.vref0, aVR2TypeII2.vref) annotation (Line(points={{0,22},{0,30},{-20,30},{-20,16},{-12,16}},
+                                                                   color={0,0,
           127}));
-  connect(Syn2.vf0, aVR2TypeII2.vf0) annotation (Line(points={{46,22},{46,28},{
-          26,28},{26,-26},{4,-26},{4,-2}},                           color={0,0,
+  connect(Syn2.vf0, aVR2TypeII2.vf0) annotation (Line(points={{44,22},{44,30},{20,30},{20,-12},{0,-12},{0,-2}},
+                                                                     color={0,0,
           127}));
   annotation (
-    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-20,-40},{120,
-            40}})),
-    Icon(coordinateSystem(extent={{-100,-100},{100,100}}, preserveAspectRatio=
-            false), graphics={
-                             Text(
+    Icon(graphics={ Text(
           extent={{-93,6},{-24,-12}},
           lineColor={0,0,255},
           textStyle={TextStyle.Italic},
           textString=""),
-          Text(extent={{-96,-20},{96,-38}},
+          Text(
+          extent={{-100,-20},{100,-40}},
           lineColor={28,108,200},
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus6.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus6.mo
@@ -64,7 +64,7 @@ equation
           lineColor={0,0,255},
           textStyle={TextStyle.Italic},
           textString=""),
-          Text(extent={{-34,-32},{38,-52}},
+          Text(extent={{-100,-34},{100,-50}},
           lineColor={28,108,200},
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus6.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus6.mo
@@ -15,7 +15,7 @@ model GroupBus6 "13.8kV/25MVA reactive power generation unit (synchronous conden
     vrmin=1.395,
     vrmax=6.81) annotation (Placement(transformation(
         extent={{-10,-10},{10,10}},
-        origin={2,10})));
+        origin={0,10})));
   OpenIPSL.Electrical.Machines.PSAT.Order6 Syn5(
     fn=60,
     D=2,
@@ -43,34 +43,33 @@ model GroupBus6 "13.8kV/25MVA reactive power generation unit (synchronous conden
   OpenIPSL.Interfaces.PwPin pwPin annotation (Placement(transformation(extent={
             {100,-10},{120,10}}),iconTransformation(extent={{100,-10},{120,10}})));
 equation
-  connect(aVR4TypeII1.vf, Syn5.vf) annotation (Line(points={{14,10},{36,10}},
+  connect(aVR4TypeII1.vf, Syn5.vf) annotation (Line(points={{12,10},{36,10}},
                              color={0,0,127}));
-  connect(Syn5.v, aVR4TypeII1.v) annotation (Line(points={{82,6},{88,6},{88,32},
-          {-22,32},{-22,4},{-10,4}},             color={0,0,127}));
+  connect(Syn5.v, aVR4TypeII1.v) annotation (Line(points={{82,6},{90,6},{90,40},{-30,40},{-30,4},{-12,4}},
+                                                 color={0,0,127}));
   connect(Syn5.p, pwPin) annotation (Line(points={{80,0},{110,0}},
                    color={0,0,255}));
-  connect(Syn5.pm0, Syn5.pm) annotation (Line(points={{44,-22},{44,-26},{28,-26},
-          {28,-10},{36,-10}},      color={0,0,127}));
-  connect(aVR4TypeII1.vref0, aVR4TypeII1.vref) annotation (Line(points={{2,22},{
-          2,28},{-16,28},{-16,16},{-10,16}},               color={0,0,127}));
-  connect(Syn5.vf0, aVR4TypeII1.vf0) annotation (Line(points={{44,22},{44,28},{
-          22,28},{22,-26},{2,-26},{2,-2}},
+  connect(Syn5.pm0, Syn5.pm) annotation (Line(points={{44,-22},{44,-28},{28,-28},{28,-10},{36,-10}},
+                                   color={0,0,127}));
+  connect(aVR4TypeII1.vref0, aVR4TypeII1.vref) annotation (Line(points={{0,22},{0,30},{-20,30},{-20,16},{-12,16}},
+                                                           color={0,0,127}));
+  connect(Syn5.vf0, aVR4TypeII1.vf0) annotation (Line(points={{44,22},{44,30},{20,30},{20,-12},{0,-12},{0,-2}},
                               color={0,0,127}));
   annotation (
-    Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
-            100}}), graphics={Text(lineColor = {0, 0, 255}, extent = {{-93, 6}, {-24, -12}}, textString = "", textStyle = {TextStyle.Italic}),
-          Text(origin={-5.31798,1}, lineColor = {28, 108, 200}, fillColor = {0, 0, 255},
-            fillPattern =                                                                              FillPattern.Solid, extent={{
-              -85.682,-23},{97.318,-37}},                                                                                                                   textString = "%name"),
+    Icon(graphics={Text(lineColor = {0, 0, 255}, extent = {{-93, 6}, {-24, -12}}, textString = "", textStyle = {TextStyle.Italic}),
+          Text(
+          lineColor={28,108,200},
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid,
+          extent={{-100,-20},{100,-40}},
+          textString="%name"),
                          Line(points={{-60,0},{-20,40},{20,0},{60,40}},
-          color={28,108,200}),Ellipse(lineColor = {28, 108, 200}, extent={{-100,
-              -100},{100,100}})}),
+          color={28,108,200}),Ellipse(lineColor = {28, 108, 200}, extent={{-100,-100},{100,100}})}),
     Documentation(info="<html>
 <p>13.8kV/25MVA Reactive power generation unit (synchronous condenser) connected to bus 6, and composed of the following component models:</p>
 <ul>
 <li><strong>Machine</strong>: 6th order, from PSAT.</li>
 <li><strong>Exciter</strong>: type II, from PSAT.</li>
 </ul>
-</html>"),
-  Diagram(coordinateSystem(extent = {{-20, 40}, {120, -40}})));
+</html>"));
 end GroupBus6;

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus6.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus6.mo
@@ -46,37 +46,31 @@ equation
   connect(aVR4TypeII1.vf, Syn5.vf) annotation (Line(points={{14,10},{36,10}},
                              color={0,0,127}));
   connect(Syn5.v, aVR4TypeII1.v) annotation (Line(points={{82,6},{88,6},{88,32},
-          {-22,32},{-22,4},{-10,4}}, color={0,0,127}));
+          {-22,32},{-22,4},{-10,4}},             color={0,0,127}));
   connect(Syn5.p, pwPin) annotation (Line(points={{80,0},{110,0}},
                    color={0,0,255}));
   connect(Syn5.pm0, Syn5.pm) annotation (Line(points={{44,-22},{44,-26},{28,-26},
-          {28,-10},{36,-10}}, color={0,0,127}));
+          {28,-10},{36,-10}},      color={0,0,127}));
   connect(aVR4TypeII1.vref0, aVR4TypeII1.vref) annotation (Line(points={{2,22},{
-          2,28},{-16,28},{-16,16},{-10,16}}, color={0,0,127}));
+          2,28},{-16,28},{-16,16},{-10,16}},               color={0,0,127}));
   connect(Syn5.vf0, aVR4TypeII1.vf0) annotation (Line(points={{44,22},{44,28},{
           22,28},{22,-26},{2,-26},{2,-2}},
                               color={0,0,127}));
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
-            100}}), graphics={
-                             Text(
-          extent={{-93,6},{-24,-12}},
-          lineColor={0,0,255},
-          textStyle={TextStyle.Italic},
-          textString=""),
-          Text(extent={{-100,-34},{100,-50}},
-          lineColor={28,108,200},
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid,
-          textString="%name"),
-                         Line(points={{-60,-20},{-20,20},{20,-20},{60,20}},
-          color={28,108,200}),Ellipse(extent={{-100,-100},{100,100}}, lineColor=
-           {28,108,200})}),
+            100}}), graphics={Text(lineColor = {0, 0, 255}, extent = {{-93, 6}, {-24, -12}}, textString = "", textStyle = {TextStyle.Italic}),
+          Text(origin={-5.31798,1}, lineColor = {28, 108, 200}, fillColor = {0, 0, 255},
+            fillPattern =                                                                              FillPattern.Solid, extent={{
+              -85.682,-23},{97.318,-37}},                                                                                                                   textString = "%name"),
+                         Line(points={{-60,0},{-20,40},{20,0},{60,40}},
+          color={28,108,200}),Ellipse(lineColor = {28, 108, 200}, extent={{-100,
+              -100},{100,100}})}),
     Documentation(info="<html>
 <p>13.8kV/25MVA Reactive power generation unit (synchronous condenser) connected to bus 6, and composed of the following component models:</p>
 <ul>
 <li><strong>Machine</strong>: 6th order, from PSAT.</li>
 <li><strong>Exciter</strong>: type II, from PSAT.</li>
 </ul>
-</html>"));
+</html>"),
+  Diagram(coordinateSystem(extent = {{-20, 40}, {120, -40}})));
 end GroupBus6;

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus8.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus8.mo
@@ -64,7 +64,7 @@ equation
           lineColor={0,0,255},
           textStyle={TextStyle.Italic},
           textString=""),
-          Text(extent={{-34,-32},{38,-52}},
+          Text(extent={{-100,-34},{100,-50}},
           lineColor={28,108,200},
           fillColor={0,0,255},
           fillPattern=FillPattern.Solid,

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus8.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus8.mo
@@ -13,9 +13,7 @@ model GroupBus8 "18kV/25MVA reactive power generation unit (synchronous condense
     Te=0.7,
     v0=v_0,
     vrmin=1.395,
-    vrmax=6.810) annotation (Placement(transformation(
-        extent={{-10,-10},{10,10}},
-        origin={-4,10})));
+    vrmax=6.810) annotation (Placement(visible = true, transformation(origin = {-2, 10}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   OpenIPSL.Electrical.Machines.PSAT.Order6 Syn4(
     fn=60,
     D=2,
@@ -41,42 +39,36 @@ model GroupBus8 "18kV/25MVA reactive power generation unit (synchronous condense
         extent={{-20,-20},{20,20}},
         origin={60,0})));
   OpenIPSL.Interfaces.PwPin pwPin annotation (Placement(transformation(extent={{100,-10},
-            {120,10}}), iconTransformation(extent={{100,-10},{120,10}})));
+            {120,10}}),         iconTransformation(extent={{100,-10},{120,10}})));
 equation
-  connect(aVR3TypeII2.vf, Syn4.vf) annotation (Line(points={{8,10},{36,10}},
-                                 color={0,0,127}));
-  connect(Syn4.v, aVR3TypeII2.v) annotation (Line(points={{82,6},{88,6},{88,-30},
-          {-22,-30},{-22,4},{-16,4}}, color={0,0,127}));
+  connect(aVR3TypeII2.vf, Syn4.vf) annotation (
+    Line(points = {{10, 10}, {36, 10}}, color = {0, 0, 127}));
+  connect(Syn4.v, aVR3TypeII2.v) annotation (
+    Line(points = {{82, 6}, {88, 6}, {88, -30}, {-18, -30}, {-18, 4}, {-14, 4}}, color = {0, 0, 127}));
   connect(Syn4.p, pwPin) annotation (Line(points={{80,0},{110,0}},
                    color={0,0,255}));
   connect(Syn4.pm0, Syn4.pm) annotation (Line(points={{44,-22},{44,-26},{18,-26},
-          {18,-10},{36,-10}}, color={0,0,127}));
-  connect(Syn4.vf0, aVR3TypeII2.vf0) annotation (Line(points={{44,22},{44,28},{
-          14,28},{14,-26},{-4,-26},{-4,-2}}, color={0,0,127}));
-  connect(aVR3TypeII2.vref0, aVR3TypeII2.vref) annotation (Line(points={{-4,22},
-          {-4,28},{-22,28},{-22,16},{-16,16}}, color={0,0,
-          127}));
+          {18,-10},{36,-10}},             color={0,0,127}));
+  connect(Syn4.vf0, aVR3TypeII2.vf0) annotation (
+    Line(points = {{44, 22}, {44, 28}, {14, 28}, {14, -26}, {-2, -26}, {-2, -2}}, color = {0, 0, 127}));
+  connect(aVR3TypeII2.vref0, aVR3TypeII2.vref) annotation (
+    Line(points = {{-2, 22}, {-2, 28}, {-18, 28}, {-18, 16}, {-14, 16}}, color = {0, 0, 127}));
   annotation (
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
-            100}}), graphics={
-                             Text(
-          extent={{-93,6},{-24,-12}},
-          lineColor={0,0,255},
-          textStyle={TextStyle.Italic},
-          textString=""),
-          Text(extent={{-100,-34},{100,-50}},
-          lineColor={28,108,200},
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid,
-          textString="%name"),
-                         Line(points={{-60,-20},{-20,20},{20,-20},{60,20}},
-          color={28,108,200}),Ellipse(extent={{-100,-100},{100,100}}, lineColor=
-           {28,108,200})}),
+            100}}), graphics={Text(lineColor = {0, 0, 255}, extent = {{-93, 6}, {-24, -12}}, textString = "", textStyle = {TextStyle.Italic}),
+          Text(origin={-4.26002,12},
+                                 lineColor = {28, 108, 200}, fillColor = {0, 0, 255},
+            fillPattern =                                                                           FillPattern.Solid, extent={{
+              -86.74,-32},{96.26,-52}},                                                                                                                  textString = "%name"),
+                         Line(points={{-60,0},{-20,40},{20,0},{60,40}},
+          color={28,108,200}),Ellipse(lineColor = {28, 108, 200}, extent={{-100,
+              -100},{100,100}})}),
     Documentation(info="<html>
 <p>18kV/25MVA Reactive power generation unit (synchronous condenser) connected to bus 8, and composed of the following component models:</p>
 <ul>
 <li><strong>Machine</strong>: 6th order, from PSAT.</li>
 <li><strong>Exciter</strong>: type II, from PSAT.</li>
 </ul>
-</html>"));
+</html>"),
+  Diagram(coordinateSystem(extent = {{-20, 40}, {120, -40}})));
 end GroupBus8;

--- a/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus8.mo
+++ b/OpenIPSL/Examples/IEEE14/Generation_Groups/GroupBus8.mo
@@ -13,7 +13,7 @@ model GroupBus8 "18kV/25MVA reactive power generation unit (synchronous condense
     Te=0.7,
     v0=v_0,
     vrmin=1.395,
-    vrmax=6.810) annotation (Placement(visible = true, transformation(origin = {-2, 10}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    vrmax=6.810) annotation (Placement(visible = true, transformation(origin={0,10}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   OpenIPSL.Electrical.Machines.PSAT.Order6 Syn4(
     fn=60,
     D=2,
@@ -39,36 +39,35 @@ model GroupBus8 "18kV/25MVA reactive power generation unit (synchronous condense
         extent={{-20,-20},{20,20}},
         origin={60,0})));
   OpenIPSL.Interfaces.PwPin pwPin annotation (Placement(transformation(extent={{100,-10},
-            {120,10}}),         iconTransformation(extent={{100,-10},{120,10}})));
+            {120,10}}), iconTransformation(extent={{100,-10},{120,10}})));
 equation
   connect(aVR3TypeII2.vf, Syn4.vf) annotation (
-    Line(points = {{10, 10}, {36, 10}}, color = {0, 0, 127}));
+    Line(points={{12,10},{36,10}}, color = {0, 0, 127}));
   connect(Syn4.v, aVR3TypeII2.v) annotation (
-    Line(points = {{82, 6}, {88, 6}, {88, -30}, {-18, -30}, {-18, 4}, {-14, 4}}, color = {0, 0, 127}));
+    Line(points={{82,6},{90,6},{90,-32},{-20,-32},{-20,4},{-12,4}}, color = {0, 0, 127}));
   connect(Syn4.p, pwPin) annotation (Line(points={{80,0},{110,0}},
                    color={0,0,255}));
-  connect(Syn4.pm0, Syn4.pm) annotation (Line(points={{44,-22},{44,-26},{18,-26},
-          {18,-10},{36,-10}},             color={0,0,127}));
+  connect(Syn4.pm0, Syn4.pm) annotation (Line(points={{44,-22},{44,-28},{28,-28},{28,-10},{36,-10}},
+                                          color={0,0,127}));
   connect(Syn4.vf0, aVR3TypeII2.vf0) annotation (
-    Line(points = {{44, 22}, {44, 28}, {14, 28}, {14, -26}, {-2, -26}, {-2, -2}}, color = {0, 0, 127}));
+    Line(points={{44,22},{44,30},{20,30},{20,-12},{0,-12},{0,-2}}, color = {0, 0, 127}));
   connect(aVR3TypeII2.vref0, aVR3TypeII2.vref) annotation (
-    Line(points = {{-2, 22}, {-2, 28}, {-18, 28}, {-18, 16}, {-14, 16}}, color = {0, 0, 127}));
+    Line(points={{0,22},{0,30},{-20,30},{-20,16},{-12,16}}, color = {0, 0, 127}));
   annotation (
-    Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
-            100}}), graphics={Text(lineColor = {0, 0, 255}, extent = {{-93, 6}, {-24, -12}}, textString = "", textStyle = {TextStyle.Italic}),
-          Text(origin={-4.26002,12},
-                                 lineColor = {28, 108, 200}, fillColor = {0, 0, 255},
-            fillPattern =                                                                           FillPattern.Solid, extent={{
-              -86.74,-32},{96.26,-52}},                                                                                                                  textString = "%name"),
+    Icon(graphics={Text(lineColor = {0, 0, 255}, extent = {{-93, 6}, {-24, -12}}, textString = "", textStyle = {TextStyle.Italic}),
+          Text(
+          lineColor={28,108,200},
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid,
+          extent={{-100,-20},{100,-40}},
+          textString="%name"),
                          Line(points={{-60,0},{-20,40},{20,0},{60,40}},
-          color={28,108,200}),Ellipse(lineColor = {28, 108, 200}, extent={{-100,
-              -100},{100,100}})}),
+          color={28,108,200}),Ellipse(lineColor = {28, 108, 200}, extent={{-100,-100},{100,100}})}),
     Documentation(info="<html>
 <p>18kV/25MVA Reactive power generation unit (synchronous condenser) connected to bus 8, and composed of the following component models:</p>
 <ul>
 <li><strong>Machine</strong>: 6th order, from PSAT.</li>
 <li><strong>Exciter</strong>: type II, from PSAT.</li>
 </ul>
-</html>"),
-  Diagram(coordinateSystem(extent = {{-20, 40}, {120, -40}})));
+</html>"));
 end GroupBus8;

--- a/OpenIPSL/Examples/IEEE14/IEEE_14_Buses.mo
+++ b/OpenIPSL/Examples/IEEE14/IEEE_14_Buses.mo
@@ -335,28 +335,28 @@ model IEEE_14_Buses "IEEE 14-bus 5-machine base test system"
     xT=0.20912) annotation (Placement(transformation(
         extent={{-14,-14},{14,14}},
         origin={64,-18})));
-  IEEE14.Generation_Groups.GroupBus2 groupBus2_1(
+  IEEE14.Generation_Groups.GroupBus2 gen2(
     V_b=69000,
     v_0=1.045,
     P_0=0.400000000000003*SysData.S_b,
     Q_0=0.948604*SysData.S_b,
     angle_0=-0.143192)
     annotation (Placement(transformation(extent={{-94,-160},{-74,-140}})));
-  IEEE14.Generation_Groups.GroupBus3 groupBus3_1(
+  IEEE14.Generation_Groups.GroupBus3 gen3(
     V_b=69000,
     v_0=1.01,
     P_0=0.000000000000001*SysData.S_b,
     Q_0=0.597359*SysData.S_b,
     angle_0=-0.3396376)
     annotation (Placement(transformation(extent={{10,-160},{30,-140}})));
-  IEEE14.Generation_Groups.GroupBus6 groupBus6_1(
+  IEEE14.Generation_Groups.GroupBus6 gen6(
     V_b=13800,
     v_0=1.07,
     P_0=0.000000000000039*SysData.S_b,
     angle_0=-0.37708,
     Q_0=0.444329*SysData.S_b)
     annotation (Placement(transformation(extent={{-96,-10},{-76,10}})));
-  IEEE14.Generation_Groups.GroupBus8 groupBus8_1(
+  IEEE14.Generation_Groups.GroupBus8 gen8(
     V_b=18000,
     v_0=1.09,
     P_0=-0.000000000000000*SysData.S_b,
@@ -385,7 +385,7 @@ model IEEE_14_Buses "IEEE 14-bus 5-machine base test system"
         extent={{-7,-7},{7,7}},
         rotation=270,
         origin={73,-51})));
-  IEEE14.Generation_Groups.GroupBus1 groupBus1_1(
+  IEEE14.Generation_Groups.GroupBus1 gen1(
     V_b=69000,
     v_0=1.06,
     angle_0=-0.00751491652,
@@ -490,11 +490,11 @@ equation
           -40},{-22,-40},{-22,-21.4},{-18,-21.4}}, color={0,0,255}));
   connect(B6.p, tWTransformerWithFixedTapRatio.n) annotation (Line(points={{-47,
           19},{-47,12},{-18,12},{-18,9.4}}, color={0,0,255}));
-  connect(groupBus2_1.pwPin, B2.p) annotation (Line(points={{-73,-150},{-60,-150},
-          {-60,-128}}, color={0,0,255}));
-  connect(groupBus3_1.pwPin, B3.p) annotation (Line(points={{31,-150},{44,-150},
-          {44,-122}}, color={0,0,255}));
-  connect(groupBus6_1.pwPin, B6.p)
+  connect(gen2.pwPin, B2.p) annotation (Line(points={{-73,-150},{-60,-150},{-60,
+          -128}}, color={0,0,255}));
+  connect(gen3.pwPin, B3.p)
+    annotation (Line(points={{31,-150},{44,-150},{44,-122}}, color={0,0,255}));
+  connect(gen6.pwPin, B6.p)
     annotation (Line(points={{-75,0},{-47,0},{-47,19}}, color={0,0,255}));
   connect(B4.p, tWTransformerWithFixedTapRatio2.p) annotation (Line(points={{32,
           -32},{36,-32},{36,-18},{48.6,-18}}, color={0,0,255}));
@@ -508,8 +508,8 @@ equation
     annotation (Line(points={{7,26},{16,26},{16,40}}, color={0,0,255}));
   connect(B5.p, L8.p) annotation (Line(points={{-24,-40},{-24,-40},{-14,-40},{-14,
           -53},{-7,-53}}, color={0,0,255}));
-  connect(B8.p, groupBus8_1.pwPin) annotation (Line(points={{149,-37},{159.5,-37},
-          {159.5,-36},{161,-36}}, color={0,0,255}));
+  connect(B8.p, gen8.pwPin) annotation (Line(points={{149,-37},{159.5,-37},{
+          159.5,-36},{161,-36}}, color={0,0,255}));
   connect(L15.p, B9.p)
     annotation (Line(points={{52,60.9},{86,60.9},{86,44}}, color={0,0,255}));
   connect(B9.p, L16.p) annotation (Line(points={{86,44},{86,44},{86,56},{96,56},
@@ -532,8 +532,8 @@ equation
   connect(L3.n, B2.p) annotation (Line(points={{-135,-105},{-135,-134},{-60,
           -134},{-60,-128}},
                        color={0,0,255}));
-  connect(groupBus1_1.pwPin, B1.p) annotation (Line(points={{-157,-6},{-135,-6},
-          {-135,-31}}, color={0,0,255}));
+  connect(gen1.pwPin, B1.p) annotation (Line(points={{-157,-6},{-135,-6},{-135,
+          -31}}, color={0,0,255}));
   connect(B4.p, pwFault2.p) annotation (Line(points={{32,-32},{32,-28},{73,-28},
           {73,-42.8333}}, color={0,0,255}));
   annotation (

--- a/OpenIPSL/Interfaces/PwPin_n.mo
+++ b/OpenIPSL/Interfaces/PwPin_n.mo
@@ -1,0 +1,22 @@
+within OpenIPSL.Interfaces;
+connector PwPin_n
+  "Connector for electrical blocks treating voltage and current as complex variables"
+  Types.PerUnit vr "Real part of the voltage";
+  Types.PerUnit vi "Imaginary part of the voltage";
+  flow Types.PerUnit ir(start=Modelica.Constants.eps) "Real part of the current";
+  flow Types.PerUnit ii(start=Modelica.Constants.eps) "Imaginary part of the current";
+  annotation (
+    Icon(graphics={Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,255},
+          fillColor={255,255,255},
+          fillPattern=FillPattern.Solid)}),
+    Diagram(graphics={Text(
+          extent={{-100,160},{100,120}},
+          lineColor={0,0,255},
+          textString="%name"),Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,255},
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid)}));
+end PwPin_n;

--- a/OpenIPSL/Interfaces/PwPin_n.mo
+++ b/OpenIPSL/Interfaces/PwPin_n.mo
@@ -13,5 +13,14 @@ connector PwPin_n
           extent={{-100,100},{100,-100}},
           lineColor={0,0,255},
           fillColor={255,255,255},
-          fillPattern=FillPattern.Solid)}));
+          fillPattern=FillPattern.Solid)}),
+    Documentation(info="<html>
+<p>
+This connector <code>PwPin_n</code> is nearly identical to 
+<a href=\"modelica://OpenIPSL.Interfaces.PwPin_p\">PwPin_p</a>
+(and <a href=\"modelica://OpenIPSL.Interfaces.PwPin\">PwPin</a>). 
+The only difference is that the default component name is set to \"n\" 
+and that the icons are different in order to identify more easily the pins of a component.
+</p>
+</html>"));
 end PwPin_n;

--- a/OpenIPSL/Interfaces/PwPin_n.mo
+++ b/OpenIPSL/Interfaces/PwPin_n.mo
@@ -1,22 +1,17 @@
 within OpenIPSL.Interfaces;
 connector PwPin_n
-  "Connector for electrical blocks treating voltage and current as complex variables"
-  Types.PerUnit vr "Real part of the voltage";
-  Types.PerUnit vi "Imaginary part of the voltage";
-  flow Types.PerUnit ir(start=Modelica.Constants.eps) "Real part of the current";
-  flow Types.PerUnit ii(start=Modelica.Constants.eps) "Imaginary part of the current";
-  annotation (
+  "Negative connector for electrical blocks treating voltage and current as complex variables"
+   extends PwPin;
+
+  annotation (defaultComponentName="n",
     Icon(graphics={Rectangle(
           extent={{-100,100},{100,-100}},
           lineColor={0,0,255},
           fillColor={255,255,255},
           fillPattern=FillPattern.Solid)}),
-    Diagram(graphics={Text(
-          extent={{-100,160},{100,120}},
-          lineColor={0,0,255},
-          textString="%name"),Rectangle(
+    Diagram(graphics={Rectangle(
           extent={{-100,100},{100,-100}},
           lineColor={0,0,255},
-          fillColor={0,0,255},
+          fillColor={255,255,255},
           fillPattern=FillPattern.Solid)}));
 end PwPin_n;

--- a/OpenIPSL/Interfaces/PwPin_p.mo
+++ b/OpenIPSL/Interfaces/PwPin_p.mo
@@ -1,0 +1,22 @@
+within OpenIPSL.Interfaces;
+connector PwPin_p
+  "Connector for electrical blocks treating voltage and current as complex variables"
+  Types.PerUnit vr "Real part of the voltage";
+  Types.PerUnit vi "Imaginary part of the voltage";
+  flow Types.PerUnit ir(start=Modelica.Constants.eps) "Real part of the current";
+  flow Types.PerUnit ii(start=Modelica.Constants.eps) "Imaginary part of the current";
+  annotation (
+    Icon(graphics={Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,255},
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid)}),
+    Diagram(graphics={Text(
+          extent={{-100,160},{100,120}},
+          lineColor={0,0,255},
+          textString="%name"),Rectangle(
+          extent={{-100,100},{100,-100}},
+          lineColor={0,0,255},
+          fillColor={0,0,255},
+          fillPattern=FillPattern.Solid)}));
+end PwPin_p;

--- a/OpenIPSL/Interfaces/PwPin_p.mo
+++ b/OpenIPSL/Interfaces/PwPin_p.mo
@@ -1,22 +1,6 @@
 within OpenIPSL.Interfaces;
 connector PwPin_p
-  "Connector for electrical blocks treating voltage and current as complex variables"
-  Types.PerUnit vr "Real part of the voltage";
-  Types.PerUnit vi "Imaginary part of the voltage";
-  flow Types.PerUnit ir(start=Modelica.Constants.eps) "Real part of the current";
-  flow Types.PerUnit ii(start=Modelica.Constants.eps) "Imaginary part of the current";
-  annotation (
-    Icon(graphics={Rectangle(
-          extent={{-100,100},{100,-100}},
-          lineColor={0,0,255},
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid)}),
-    Diagram(graphics={Text(
-          extent={{-100,160},{100,120}},
-          lineColor={0,0,255},
-          textString="%name"),Rectangle(
-          extent={{-100,100},{100,-100}},
-          lineColor={0,0,255},
-          fillColor={0,0,255},
-          fillPattern=FillPattern.Solid)}));
+  "Positive connector for electrical blocks treating voltage and current as complex variables"
+ extends PwPin;
+ annotation (defaultComponentName="p");
 end PwPin_p;

--- a/OpenIPSL/Interfaces/PwPin_p.mo
+++ b/OpenIPSL/Interfaces/PwPin_p.mo
@@ -2,5 +2,12 @@ within OpenIPSL.Interfaces;
 connector PwPin_p
   "Positive connector for electrical blocks treating voltage and current as complex variables"
  extends PwPin;
- annotation (defaultComponentName="p");
+ annotation (defaultComponentName="p", Documentation(info="<html>
+<p>
+This connector <code>PwPin_p</code> is nearly identical to 
+<a href=\"modelica://OpenIPSL.Interfaces.PwPin\">PwPin</a>. 
+The only difference is that the default component name is set to \"p\" 
+in order to identify more easily the pins of a component.
+</p>
+</html>"));
 end PwPin_p;

--- a/OpenIPSL/Interfaces/package.order
+++ b/OpenIPSL/Interfaces/package.order
@@ -1,2 +1,4 @@
 PwPin
+PwPin_p
+PwPin_n
 Generator


### PR DESCRIPTION
I've implemented some graphical enhancements to the library.
Mainly:
1. enlarged the text boxes so that more space is mada available to theri content. The previous text boxes caused nearly always the names to be truncated with ellipises
2. visually differentiated positive and negative pins in lines and transformers. Now, in compliance with the de-facto standard of Modelica Standard library, the positive pins are blue-fitted, the negative ones white fitted..

More details are available in the comments of individual commit composing thsi PR.
