### PR TITLE
Fix regex to optionally ignore quoted strings when checking for deprecated Text.lineColor annotation

### DIFF
--- a/.CI/check_deprecated_line_color.py
+++ b/.CI/check_deprecated_line_color.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 '''
-Copyright (C) 2021, Modelica Association and contributors
+Copyright (C) 2021-2023, Modelica Association and contributors
 All rights reserved.
 
 Check for deprecated Text.lineColor annotation
@@ -13,7 +13,7 @@ import os
 import re
 import sys
 
-PATTERN = re.compile(r'(Text\s*\([^\).]*)lineColor')
+PATTERN = re.compile(r'(?:Text\s*\([^\)]*?(?:\"(?:\\.|[^\"])*\")?[^\)]*?)(lineColor)')
 
 def _checkDeprecatedFileLineColor(file_name):
     errors = 0


### PR DESCRIPTION
Previously, a Text.lineColor annotation was not detected, if there was a closing parenthesis (within a quoted Text.textString annotation), e.g.

```mo
Text(extent={{-100,80},{-80,60}}, textString="1)", lineColor={0,0,255})
```