### PR TITLE
Adding input option to voltage source behind an impedance model

### DIFF
--- a/OpenIPSL/Electrical/Sources/SourceBehindImpedance/BaseClasses/baseVoltageSource.mo
+++ b/OpenIPSL/Electrical/Sources/SourceBehindImpedance/BaseClasses/baseVoltageSource.mo
@@ -28,19 +28,19 @@ partial model baseVoltageSource
   RealOutput Emag0(start=E0)
     "Initial value of the internal voltage source magnitude"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={-40,-110}),
+        rotation=90,
+        origin={0,110}),
         iconTransformation(extent={{-10,-10},{10,10}},
-        rotation=270,
-        origin={-40,-110})));
+        rotation=90,
+        origin={0,110})));
   RealOutput Eang0(start=delta0)
     "Initial value of the internal voltage angle"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={40,-110}),
+        origin={0,-110}),
         iconTransformation(extent={{-10,-10},{10,10}},
         rotation=270,
-        origin={40,-110})));
+        origin={0,-110})));
   parameter OpenIPSL.Types.ApparentPower M_b=SysData.S_b "Voltage Source base power rating (MVA)"
     annotation (Dialog(group="Voltage Source parameters"));
   parameter OpenIPSL.Types.PerUnit R_a=1e-3 "Internal source resistance, pu, system base"

--- a/OpenIPSL/Electrical/Sources/SourceBehindImpedance/VoltageSources/VSourceIO.mo
+++ b/OpenIPSL/Electrical/Sources/SourceBehindImpedance/VoltageSources/VSourceIO.mo
@@ -12,12 +12,36 @@ model VSourceIO
   Modelica.Blocks.Math.PolarToRectangular p2R
     "Convert from magnitude and angle to real and imaginary"
     annotation (Placement(transformation(extent={{-42,-22},{0,20}})));
+  // Includes conditional option to set the input as a deviation from
+  // the initialization value, or to use the input as a whole quantity.
+  parameter Boolean useEphasorInternalAsInput = true
+  "If true, the values of E0 and delta0 are computed internally and used
+  as the start value of the input, requiring only a deviation \\Delta E and 
+  \\Delta delta to be supplied. 
+  If false, the magnitude E and angle delta must be supplied, including
+  the correct value of E0 and delta0 needed for proper initialization.";
 equation
   // Internal voltage source equations
-  delta = delta0 + uDEang "Initial angle plus input increment";
-  E = E0 + uDEmag "Initial magnitude plus input increment";
-  Er = Er0 + p2R.y_re;
-  Ei = Ei0 + p2R.y_im;
+  if useEphasorInternalAsInput then
+    // Condition: true
+    // This injects a signal that is a deviation from the inital value of
+    // E0 and delta0, for the two variables, which are calculated in the base class.
+    delta = delta0 + uDEang "Initial angle plus input increment";
+    E = E0 + uDEmag "Initial magnitude plus input increment";
+    Er = Er0 + p2R.y_re;
+    Ei = Ei0 + p2R.y_im;
+
+  else
+    // Condition: false
+    // This injects a voltage phasor to define the internal voltage of the
+    // source, as the internally computed values that are needed to initialize
+    // properly E and delta (E0 and delta0) are not included, they need to be
+    // provided externally by the user.
+    delta = uDEang   "Internal voltage angle, delta, provided by the graphical input uDEang";
+    E = uDEmag   "Internal voltage magnitude, E, provided by the graphical input uDEmag";
+    Er = p2R.y_re "Real part of phasor calculated with the p2R block on the diagram layer";
+    Ei = p2R.y_im "Imaginary part of phasor calculated with the p2R block on the diagram layer";
+  end if;
   connect(p2R.u_abs, uDEmag) annotation (Line(points={{-46.2,11.6},{-94,11.6},{
           -94,60},{-120,60}}, color={0,0,127}));
   connect(p2R.u_arg, uDEang) annotation (Line(points={{-46.2,-13.6},{-94,-13.6},
@@ -97,16 +121,7 @@ which are the real and imaginary input
           textColor={0,0,0},
           textString="%name")}),
     Documentation(info="<html>
-<p>
-The purpose of this model is to support the development of Grid-Forming Inverter models as described in
-<a href=\"modelica://OpenIPSL.UsersGuide.References\">[Du2021]</a>.
-The model provides a voltage source with an internal voltage source and internal impedance
-whose magnitude and angle can be varied via inputs starting from their initial values.
-</p>
-<p>
-See the documentation of
-<a href=\"Modelica://OpenIPSL.Electrical.Sources.SourceBehindImpedance.BaseClasses.baseVoltageSource\">BaseClasses.baseVoltageSource</a>
-for more information.
-</p>
+<p>The purpose of this model is to support the development of Grid-Forming Inverter models as described in <a href=\"modelica://OpenIPSL.UsersGuide.References\">[Du2021]</a>. The model provides a voltage source with an internal voltage source and internal impedance whose magnitude and angle can be varied via inputs starting from their initial values. </p>
+<p>See the documentation of <a href=\"Modelica://OpenIPSL.Electrical.Sources.SourceBehindImpedance.BaseClasses.baseVoltageSource\">BaseClasses.baseVoltageSource</a> for more information. </p>
 </html>"));
 end VSourceIO;

--- a/OpenIPSL/Tests/Sources/SourcesBehindImpedance/VSourceIO.mo
+++ b/OpenIPSL/Tests/Sources/SourcesBehindImpedance/VSourceIO.mo
@@ -11,7 +11,8 @@ model VSourceIO
     Q_0=5416582,
     v_0=1.0,
     angle_0=0.070492225331847,
-    M_b=SysData.S_b)
+    M_b=SysData.S_b,
+    useEphasorInternalAsInput=true)
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
   Modelica.Blocks.Sources.Ramp DEang(
     height=Modelica.Units.Conversions.from_deg(20),

--- a/OpenIPSL/Tests/Sources/SourcesBehindImpedance/VSourceIO.mo
+++ b/OpenIPSL/Tests/Sources/SourcesBehindImpedance/VSourceIO.mo
@@ -11,8 +11,7 @@ model VSourceIO
     Q_0=5416582,
     v_0=1.0,
     angle_0=0.070492225331847,
-    M_b=SysData.S_b,
-    useEphasorInternalAsInput=true)
+    M_b=SysData.S_b)
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
   Modelica.Blocks.Sources.Ramp DEang(
     height=Modelica.Units.Conversions.from_deg(20),

--- a/OpenIPSL/Tests/Sources/SourcesBehindImpedance/VSourceIO_StartFromExternal_using_RealExpression.mo
+++ b/OpenIPSL/Tests/Sources/SourcesBehindImpedance/VSourceIO_StartFromExternal_using_RealExpression.mo
@@ -1,0 +1,66 @@
+within OpenIPSL.Tests.Sources.SourcesBehindImpedance;
+model VSourceIO_StartFromExternal_using_RealExpression
+  "Tests the voltage source behind an impedance component that includes inputs, this example starts from the value provided externally."
+  extends OpenIPSL.Tests.BaseClasses.SMIB(pwFault(
+      R=1e-6,
+      X=1e-3,
+      t1=2,
+      t2=2.05));
+  Electrical.Sources.SourceBehindImpedance.VoltageSources.VSourceIO VSIO(
+    P_0=40000000,
+    Q_0=5416582,
+    v_0=1.0,
+    angle_0=0.070492225331847,
+    M_b=SysData.S_b,
+    useEphasorInternalAsInput=false)
+    annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
+  Modelica.Blocks.Sources.Ramp DEm(
+    height=0.3,
+    duration=1,
+    startTime=4)
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-90,70})));
+  Modelica.Blocks.Math.Add addE0_DE annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-70,30})));
+  Modelica.Blocks.Sources.RealExpression E0(y=VSIO.Emag0) annotation (Placement(
+        transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-64,68})));
+  Modelica.Blocks.Math.Add addEang_DEang annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-70,-30})));
+  Modelica.Blocks.Sources.RealExpression delta0(y=VSIO.Eang0) annotation (
+      Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-64,-70})));
+  Modelica.Blocks.Sources.Ramp DEang(
+    height=Modelica.Units.Conversions.from_deg(20),
+    duration=3,
+    startTime=6)
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-90,-70})));
+equation
+  connect(VSIO.p, GEN1.p)
+    annotation (Line(points={{-39,0},{-30,0}}, color={0,0,255}));
+  connect(addE0_DE.y, VSIO.uDEmag)
+    annotation (Line(points={{-70,19},{-70,6},{-62,6}}, color={0,0,127}));
+  connect(addEang_DEang.y, VSIO.uDEang)
+    annotation (Line(points={{-70,-19},{-70,-6},{-62,-6}}, color={0,0,127}));
+  connect(DEm.y, addE0_DE.u2) annotation (Line(points={{-90,59},{-90,50},{-76,
+          50},{-76,42}}, color={0,0,127}));
+  connect(DEang.y, addEang_DEang.u1) annotation (Line(points={{-90,-59},{-90,
+          -50},{-76,-50},{-76,-42}}, color={0,0,127}));
+  connect(delta0.y, addEang_DEang.u2)
+    annotation (Line(points={{-64,-59},{-64,-42}}, color={0,0,127}));
+  connect(E0.y, addE0_DE.u1)
+    annotation (Line(points={{-64,57},{-64,42}}, color={0,0,127}));
+annotation(preferredView="diagram", experiment(StopTime=10));
+
+end VSourceIO_StartFromExternal_using_RealExpression;

--- a/OpenIPSL/Tests/Sources/SourcesBehindImpedance/VSourceIO_StartFromExternal_using_VSIO_outputs.mo
+++ b/OpenIPSL/Tests/Sources/SourcesBehindImpedance/VSourceIO_StartFromExternal_using_VSIO_outputs.mo
@@ -1,0 +1,56 @@
+within OpenIPSL.Tests.Sources.SourcesBehindImpedance;
+model VSourceIO_StartFromExternal_using_VSIO_outputs
+  "Tests the voltage source behind an impedance component that includes inputs, this example starts from the value provided externally."
+  extends OpenIPSL.Tests.BaseClasses.SMIB(pwFault(
+      R=1e-6,
+      X=1e-3,
+      t1=2,
+      t2=2.05));
+  Electrical.Sources.SourceBehindImpedance.VoltageSources.VSourceIO VSIO(
+    P_0=40000000,
+    Q_0=5416582,
+    v_0=1.0,
+    angle_0=0.070492225331847,
+    M_b=SysData.S_b,
+    useEphasorInternalAsInput=false)
+    annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
+  Modelica.Blocks.Sources.Ramp DEang(
+    height=Modelica.Units.Conversions.from_deg(20),
+    duration=3,
+    startTime=6)
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-90,-70})));
+  Modelica.Blocks.Sources.Ramp DEm(
+    height=0.3,
+    duration=1,
+    startTime=4)
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-90,70})));
+  Modelica.Blocks.Math.Add addE0_DE annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=270,
+        origin={-70,30})));
+  Modelica.Blocks.Math.Add addEang_DEang annotation (Placement(transformation(
+        extent={{-10,-10},{10,10}},
+        rotation=90,
+        origin={-70,-30})));
+equation
+  connect(VSIO.p, GEN1.p)
+    annotation (Line(points={{-39,0},{-30,0}}, color={0,0,255}));
+  connect(addE0_DE.y, VSIO.uDEmag)
+    annotation (Line(points={{-70,19},{-70,6},{-62,6}}, color={0,0,127}));
+  connect(addEang_DEang.y, VSIO.uDEang)
+    annotation (Line(points={{-70,-19},{-70,-6},{-62,-6}}, color={0,0,127}));
+  connect(DEm.y, addE0_DE.u2) annotation (Line(points={{-90,59},{-90,50},{-76,
+          50},{-76,42}}, color={0,0,127}));
+  connect(DEang.y, addEang_DEang.u1) annotation (Line(points={{-90,-59},{-90,
+          -50},{-76,-50},{-76,-42}}, color={0,0,127}));
+  connect(addEang_DEang.u2, VSIO.Eang0) annotation (Line(points={{-64,-42},{-64,
+          -50},{-50,-50},{-50,-11}}, color={0,0,127}));
+  connect(VSIO.Emag0, addE0_DE.u1) annotation (Line(points={{-50,11},{-50,48},{
+          -64,48},{-64,42}}, color={0,0,127}));
+annotation(preferredView="diagram", experiment(StopTime=10));
+
+end VSourceIO_StartFromExternal_using_VSIO_outputs;

--- a/OpenIPSL/Tests/Sources/SourcesBehindImpedance/package.order
+++ b/OpenIPSL/Tests/Sources/SourcesBehindImpedance/package.order
@@ -1,2 +1,4 @@
 VSource
 VSourceIO
+VSourceIO_StartFromExternal_using_VSIO_outputs
+VSourceIO_StartFromExternal_using_RealExpression

--- a/OpenIPSL/Tests/Sources/SourcesBehindImpedance/package.order
+++ b/OpenIPSL/Tests/Sources/SourcesBehindImpedance/package.order
@@ -1,4 +1,4 @@
 VSource
 VSourceIO
-VSourceIO_StartFromExternal_using_VSIO_outputs
 VSourceIO_StartFromExternal_using_RealExpression
+VSourceIO_StartFromExternal_using_VSIO_outputs


### PR DESCRIPTION
Changes/Additions to components:
- Change to base class in order to move the outputs to more convenient location for wiring.
- Changed VSourceIO to provide 2 options. One that sets value of the voltage source starting from the value calculated internally (E0 and delta0) and another one that does not. This is needed to be able to link the control blocks of a grid forming converter, that needs to start from E0 and delta0 itself, similar to what is done with synch machines.

Changes to the Tests:
- Modified the VSourceIO to set the flag to "true", given the options above.

Additions:
- Added two examples of how the internally calculated E0 and delta0 need to be provided for adequate initialization.
