### PR TITLE
Update Reals IEE2ST, REECA1, REECB1, REECCU1, and REPCA1

### DIFF
--- a/OpenIPSL/Electrical/Controls/PSSE/PSS/IEE2ST.mo
+++ b/OpenIPSL/Electrical/Controls/PSSE/PSS/IEE2ST.mo
@@ -76,19 +76,19 @@ initial equation
   ICS10 = V_S1;
   ICS20 = V_S2;
 equation
-  if V_CU == 0 and not V_CL == 0 then
+  if not (V_CU < 0 or V_CU > 0) and (V_CL < 0 or V_CL > 0) then
     if VCT > V_CL then
       VOTHSG = VSS;
     else
       VOTHSG = 0;
     end if;
-  elseif V_CL == 0 and not V_CU == 0 then
+  elseif not (V_CL < 0 or V_CL > 0) and (V_CU < 0 or V_CU > 0) then
     if VCT < V_CU then
       VOTHSG = VSS;
     else
       VOTHSG = 0;
     end if;
-  elseif V_CU == 0 and V_CL == 0 then
+  elseif not (V_CU < 0 or V_CU > 0) and not (V_CL < 0 or V_CL > 0) then
     VOTHSG = VSS;
   elseif VCT > V_CL and VCT < V_CU then
     VOTHSG = VSS;

--- a/OpenIPSL/Electrical/Renewables/PSSE/ElectricalController/REECA1.mo
+++ b/OpenIPSL/Electrical/Renewables/PSSE/ElectricalController/REECA1.mo
@@ -217,7 +217,7 @@ protected
   parameter OpenIPSL.Types.PerUnit V0(fixed=false);
   parameter OpenIPSL.Types.PerUnit p00(fixed=false);
   parameter OpenIPSL.Types.PerUnit q00(fixed=false);
-  parameter OpenIPSL.Types.PerUnit Vref0 = if vref0 == 0 then V0 else vref0;
+  parameter OpenIPSL.Types.PerUnit Vref0 = if (vref0 > 0 or vref0 < 0) then vref0 else V0;
   OpenIPSL.Types.PerUnit Vmod;
 initial equation
 

--- a/OpenIPSL/Electrical/Renewables/PSSE/ElectricalController/REECB1.mo
+++ b/OpenIPSL/Electrical/Renewables/PSSE/ElectricalController/REECB1.mo
@@ -199,7 +199,7 @@ protected
   parameter OpenIPSL.Types.PerUnit V0(fixed=false);
   parameter OpenIPSL.Types.PerUnit p00(fixed=false);
   parameter OpenIPSL.Types.PerUnit q00(fixed=false);
-  parameter OpenIPSL.Types.PerUnit Vref0 = if vref0 == 0 then V0 else vref0;
+  parameter OpenIPSL.Types.PerUnit Vref0 = if (vref0 > 0 or vref0 < 0) then vref0 else V0;
 
 initial equation
 

--- a/OpenIPSL/Electrical/Renewables/PSSE/ElectricalController/REECCU1.mo
+++ b/OpenIPSL/Electrical/Renewables/PSSE/ElectricalController/REECCU1.mo
@@ -266,7 +266,7 @@ protected
   parameter OpenIPSL.Types.PerUnit V0(fixed=false);
   parameter OpenIPSL.Types.PerUnit p00(fixed=false);
   parameter OpenIPSL.Types.PerUnit q00(fixed=false);
-  parameter OpenIPSL.Types.PerUnit Vref0 = if vref0 == 0 then V0 else vref0;
+  parameter OpenIPSL.Types.PerUnit Vref0 = if (vref0 > 0 or vref0 < 0) then vref0 else V0;
 
 initial equation
 

--- a/OpenIPSL/Electrical/Renewables/PSSE/PlantController/REPCA1.mo
+++ b/OpenIPSL/Electrical/Renewables/PSSE/PlantController/REPCA1.mo
@@ -140,7 +140,7 @@ protected
   parameter OpenIPSL.Types.PerUnit V0(fixed=false);
   parameter OpenIPSL.Types.PerUnit p00(fixed=false);
   parameter OpenIPSL.Types.PerUnit q00(fixed=false);
-  parameter OpenIPSL.Types.PerUnit Vref0 = if Vref == 0 then V0 else Vref;
+  parameter OpenIPSL.Types.PerUnit Vref0 = if (Vref > 0 or Vref < 0) then Vref else V0;
 
 initial equation
 


### PR DESCRIPTION
Fixes #365 
Modify == to <0 or >0 on IEE2ST, REECA1, REECB1, REECCU1, and REPCA1. This applies to models and not functions such as SE or atan3.