### PR TITLE
Parameter evaluation for simpler initial equation systems

### DIFF
--- a/OpenIPSL/NonElectrical/Continuous/SimpleLag.mo
+++ b/OpenIPSL/NonElectrical/Continuous/SimpleLag.mo
@@ -5,7 +5,7 @@ block SimpleLag "First order lag transfer function block"
     annotation (Placement(transformation(extent={{-58,32},{-38,52}})));
   Real state(start=y_start);
   parameter Real K "Gain";
-  parameter Types.Time T "Lag time constant";
+  parameter Types.Time T "Lag time constant" annotation(Evaluate = true);
   parameter Real y_start "Output start value";
 protected
   parameter Real T_mod=if T < Modelica.Constants.eps then 1000 else T;

--- a/OpenIPSL/NonElectrical/Continuous/SimpleLagLimVar.mo
+++ b/OpenIPSL/NonElectrical/Continuous/SimpleLagLimVar.mo
@@ -15,7 +15,7 @@ block SimpleLagLimVar
   Modelica.Blocks.Sources.RealExpression const(y=T)
     annotation (Placement(transformation(extent={{-58,32},{-38,52}})));
   parameter Real K "Gain";
-  parameter Types.Time T "Lag time constant";
+  parameter Types.Time T "Lag time constant" annotation(Evaluate = true);
   parameter Real y_start "Output start value";
   parameter Real T_mod=if T < Modelica.Constants.eps then 1000 else T;
   Real state;


### PR DESCRIPTION
This suggests evaluation of two parameters, which simplifies the initial equation systems.

For Wolfram System Modeler, this breaks apart some equation blocks sufficiently that these models can be built and simulated:
```
OpenIPSL.Tests.Controls.PSSE.ES.ST5B
OpenIPSL.Tests.Controls.PSSE.ES.ESST4B
OpenIPSL.Tests.Controls.PSSE.ES.EXST1
OpenIPSL.Examples.RaPIdExperiments.Mostar
OpenIPSL.Examples.DAEMode.SMIB_Examples.Example_1.Network3
OpenIPSL.Examples.SevenBus.Network
```
See #368.